### PR TITLE
Report status info to monitoring site

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -477,6 +477,8 @@ while ($true) {
         }
     }
 
+    if($MinerStatusURL) { .\ReportStatus.ps1 -Address $WalletBackup -WorkerName $WorkerNameBackup -ActiveMiners $ActiveMiners -Miners $Miners -MinerStatusURL $MinerStatusURL }
+
     #Display mining information
     Clear-Host
     $Miners | Where-Object {$_.Profit -ge 1E-5 -or $_.Profit -eq $null} | Sort-Object -Descending Type, Profit_Bias | Format-Table -GroupBy Type (

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -40,7 +40,9 @@ param(
     [Parameter(Mandatory = $false)]
     [Int]$Delay = 0, #seconds before opening each miner
     [Parameter(Mandatory = $false)]
-    [Switch]$Watchdog = $false, 
+    [Switch]$Watchdog = $false,
+    [Parameter(Mandatory = $false)]
+    [String]$MinerStatusURL,
     [Parameter(Mandatory = $false)]
     [Int]$SwitchingPrevention = 1 #zero does not prevent miners switching
 )

--- a/ReportStatus.ps1
+++ b/ReportStatus.ps1
@@ -1,0 +1,33 @@
+﻿using module .\Include.psm1
+
+param(
+    [Parameter(Mandatory=$true)][String]$Address,
+    [Parameter(Mandatory=$true)][String]$WorkerName,
+    [Parameter(Mandatory=$true)]$ActiveMiners,
+    [Parameter(Mandatory=$true)]$Miners,
+    [Parameter(Mandatory=$true)]$MinerStatusURL
+)
+
+Write-Host "Pinging monitoring server..."
+$profit = "{0:N8}" -f (($ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.Status -eq "Running"} | Measure-Object Profit -Sum).Sum)
+
+# Format the miner values for reporting.  Set relative path so the server doesn't store anything personal (like your system username, if running from somewhere in your profile)
+$minerreport = ConvertTo-Json @($ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.Status -eq "Running"} | Foreach-Object {
+    $ActiveMiner = $_
+    # Find the matching entry in $Miners, to get pool information. Perhaps there is a better way to do this?
+    $MatchingMiner = $Miners | Where-Object {$_.Name -eq $ActiveMiner.Name -and $_.Path -eq $ActiveMiner.Path -and $_.Arguments -eq $ActiveMiner.Arguments -and $_.Wrap -eq $ActiveMiner.Wrap -and $_.API -eq $ActiveMiner.API -and $_.Port -eq $ActiveMiner.Port}
+    # Create a custom object to convert to json. Type, Pool, CurrentSpeed and EstimatedSpeed are all forced to be arrays, since they sometimes have multiple values.
+    [pscustomobject]@{
+        Name = $_.Name
+        Path = Resolve-Path -Relative $_.Path
+        Type = @($_.Type)
+        Active = "{0:dd} Days {0:hh} Hours {0:mm} Minutes" -f ((Get-Date) - $_.Process.StartTime)
+        Algorithm = @($_.Algorithm)
+        Pool = @($MatchingMiner.Pools.PsObject.Properties.Value.Name)
+        CurrentSpeed = @($_.Speed_Live | Foreach-Object {"$($_ | ConvertTo-Hash)/s"})
+        EstimatedSpeed = @($_.Speed | Foreach-Object {"$($_ | ConvertTo-Hash)/s"})
+        PID = $_.Process.Id
+        'BTC/day' = "{0:N8}" -f $_.Profit
+    }
+})
+Invoke-RestMethod -Uri $MinerStatusURL -Method Post -Body @{address = $Address; workername = $WorkerName; miners = $minerreport; profit = $profit}


### PR DESCRIPTION
I needed a way to monitor all my workers and make sure none of them have died, rebooted for windows updates, etc.  This adds a feature to send a web request to a remote monitoring server on every loop.

It's intended to report to the web interface I built here: https://github.com/grantemsley/mpm-monitor, but anyone could build their own web interface or android app or whatever to store and view the data.
![image 2](https://user-images.githubusercontent.com/669579/34320298-fdb8073e-e7c4-11e7-9038-8550bea62a25.png)

If you want to test it against my web server, the MinerStatusURL is "http://mining.emsley.ca/miner.php", and you can lookup your address at "http://mining.emsley.ca".  Just add "-MinerStatusURL http://mining.emsley.ca/miner.php" to your parameters in Start.bat 

