### PR TITLE
Logging with timestamps and error levels

### DIFF
--- a/APIs/Cast.ps1
+++ b/APIs/Cast.ps1
@@ -19,7 +19,7 @@ class Cast : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Ccminer.ps1
+++ b/APIs/Ccminer.ps1
@@ -19,7 +19,7 @@ class Ccminer : Miner {
                 $Data = $Response -split ";" | ConvertFrom-StringData -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Claymore.ps1
+++ b/APIs/Claymore.ps1
@@ -19,7 +19,7 @@ class Claymore : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Dstm.ps1
+++ b/APIs/Dstm.ps1
@@ -19,7 +19,7 @@ class Dstm : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Eminer.ps1
+++ b/APIs/Eminer.ps1
@@ -19,7 +19,7 @@ class Eminer : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Nicehash.ps1
+++ b/APIs/Nicehash.ps1
@@ -19,7 +19,7 @@ class Nicehash : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error  "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Prospector.ps1
+++ b/APIs/Prospector.ps1
@@ -19,7 +19,7 @@ class Prospector : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Wrapper.ps1
+++ b/APIs/Wrapper.ps1
@@ -26,7 +26,7 @@ class Wrapper : Miner {
                 }
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Xgminer.ps1
+++ b/APIs/Xgminer.ps1
@@ -17,7 +17,7 @@ class Xgminer : Miner {
                 $Data = $Response.Substring($Response.IndexOf("{"), $Response.LastIndexOf("}") - $Response.IndexOf("{") + 1) -replace " ", "_" | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error  "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/APIs/Xmrig.ps1
+++ b/APIs/Xmrig.ps1
@@ -19,7 +19,7 @@ class Xmrig : Miner {
                 $Data = $Response | ConvertFrom-Json -ErrorAction Stop
             }
             catch {
-                Write-Warning "Failed to connect to miner ($($this.Name)). "
+                Write-Log -Level Error "Failed to connect to miner ($($this.Name)). "
                 break
             }
 

--- a/Downloader.ps1
+++ b/Downloader.ps1
@@ -33,11 +33,11 @@ $DownloadList | ForEach-Object {
             Write-Progress -Activity "Downloader" -Status $Path -CurrentOperation "Acquiring Offline (Computer)" -PercentComplete $Progress
 
             $ProgressPreference = "SilentlyContinue"
-            if ($URI) {Write-Warning "Cannot download $($Path) distributed at $($URI). "}
-            else {Write-Warning "Cannot download $($Path). "}
+            if ($URI) {Write-Log -Level Warn "Cannot download $($Path) distributed at $($URI). "}
+            else {Write-Log -Level Warn "Cannot download $($Path). "}
 
             if ($Searchable) {
-                Write-Warning "Searching for $($Path). "
+                Write-Log -Level Warn "Searching for $($Path). "
 
                 $Path_Old = Get-PSDrive -PSProvider FileSystem | ForEach-Object {Get-ChildItem -Path $_.Root -Include (Split-Path $Path -Leaf) -Recurse -ErrorAction Ignore} | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
                 $Path_New = $Path
@@ -48,8 +48,8 @@ $DownloadList | ForEach-Object {
                 (Split-Path $Path_Old) | Copy-Item -Destination (Split-Path $Path_New) -Recurse -Force
             }
             else {
-                if ($URI) {Write-Warning "Cannot find $($Path) distributed at $($URI). "}
-                else {Write-Warning "Cannot find $($Path). "}
+                if ($URI) {Write-Log -Level Warn "Cannot find $($Path) distributed at $($URI). "}
+                else {Write-Log -Level Warn "Cannot find $($Path). "}
             }
         }
         $ProgressPreference = $ProgressPreferenceBackup

--- a/Include.psm1
+++ b/Include.psm1
@@ -9,12 +9,10 @@ Function Write-Log {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true)][ValidateNotNullOrEmpty()][Alias("LogContent")][string]$Message,
-        [Parameter(Mandatory=$false)][ValidateSet("Error","Warn","Info","Debug")][string]$Level = "Info"
+        [Parameter(Mandatory=$false)][ValidateSet("Error","Warn","Info","Verbose","Debug")][string]$Level = "Info"
     )
 
-    Begin {
-        $VerbosePreference = 'Continue'
-    }
+    Begin { }
     Process {
         $filename = ".\Logs\MultiPoolMiner-$(Get-Date -Format "yyyy-MM-dd").txt"
         $date = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -24,19 +22,31 @@ Function Write-Log {
         switch($Level) {
             'Error' {
                 $LevelText = 'ERROR:'
-                Write-Host -ForegroundColor Red -Object "$date $LevelText $Message"
+                if($ErrorActionPreference -ne 'SilentlyContinue') {
+                    Write-Host -ForegroundColor Red -Object "$date $LevelText $Message"
+                }
             }
             'Warn' {
                 $LevelText = 'WARNING:'
-                Write-Host -ForegroundColor Yellow -Object "$date $LevelText $Message"
+                if($WarningPreference -ne 'SilentlyContinue') {
+                    Write-Host -ForegroundColor Yellow -Object "$date $LevelText $Message"
+                }
             }
             'Info' {
                 $LevelText = 'INFO:'
                 Write-Host -ForegroundColor DarkCyan -Object "$date $LevelText $Message"
             }
+            'Verbose' {
+                $LevelText = 'VERBOSE:'
+                if($VerbosePreference -ne 'SilentlyContinue') {
+                    Write-Host -ForegroundColor Cyan -Object "$date $LevelText $Message"
+                }
+            }
             'Debug' {
                 $LevelText = 'DEBUG:'
-                Write-Host -ForegroundColor Gray -Object "$date $LevelText $Message"
+                if($DebugPreference -ne 'SilentlyContinue') {
+                    Write-Host -ForegroundColor Gray -Object "$date $LevelText $Message"
+                }
             }
         }
         "$date $LevelText $Message" | Out-File -FilePath $filename -Append

--- a/Include.psm1
+++ b/Include.psm1
@@ -5,6 +5,39 @@ Set-Location (Split-Path $MyInvocation.MyCommand.Path)
 
 Add-Type -Path .\OpenCL\*.cs
 
+Function Write-Log {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true)][ValidateNotNullOrEmpty()][Alias("LogContent")][string]$Message,
+        [Parameter(Mandatory=$false)][ValidateSet("Error","Warn","Info")][string]$Level = "Info"
+    )
+
+    Begin {
+        $VerbosePreference = 'Continue'
+    }
+    Process {
+        $filename = ".\Logs\MultiPoolMiner-$(Get-Date -Format "yyyy-MM-dd").txt"
+        $date = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+
+        switch($Level) {
+            'Error' {
+                $LevelText = 'ERROR:'
+                Write-Host -ForegroundColor Red -Object "$date $LevelText $Message"
+            }
+            'Warn' {
+                $LevelText = 'WARNING:'
+                Write-Host -ForegroundColor Yellow -Object "$date $LevelText $Message"
+            }
+            'Info' {
+                $LevelText = 'INFO:'
+                Write-Host -ForegroundColor DarkCyan -Object "$date $LevelText $Message"
+            }
+        }
+        "$date $LevelText $Message" | Out-File -FilePath $filename -Append
+    }
+    End {}
+}
+
 function Set-Stat {
     [CmdletBinding()]
     param(
@@ -59,7 +92,7 @@ function Set-Stat {
         if ($ChangeDetection -and $Value -eq $Stat.Live) {$Updated -eq $Stat.updated}
 
         if ($Value -lt $ToleranceMin -or $Value -gt $ToleranceMax) {
-            Write-Warning "Stat file ($Name) was not updated because the value ($([Decimal]$Value)) is outside fault tolerance ($([Int]$ToleranceMin) ... $([Int]$ToleranceMax)). "
+            Write-Log -Level Warn "Stat file ($Name) was not updated because the value ($([Decimal]$Value)) is outside fault tolerance ($([Int]$ToleranceMin) ... $([Int]$ToleranceMax)). "
         }
         else {
             $Span_Minute = [Math]::Min($Duration.TotalMinutes / [Math]::Min($Stat.Duration.TotalMinutes, 1), 1)
@@ -95,7 +128,7 @@ function Set-Stat {
         }
     }
     catch {
-        if (Test-Path $Path) {Write-Warning "Stat file ($Name) is corrupt and will be reset. "}
+        if (Test-Path $Path) {Write-Log -Level Warn "Stat file ($Name) is corrupt and will be reset. "}
 
         $Stat = [PSCustomObject]@{
             Live = $Value

--- a/Include.psm1
+++ b/Include.psm1
@@ -9,7 +9,7 @@ Function Write-Log {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true)][ValidateNotNullOrEmpty()][Alias("LogContent")][string]$Message,
-        [Parameter(Mandatory=$false)][ValidateSet("Error","Warn","Info")][string]$Level = "Info"
+        [Parameter(Mandatory=$false)][ValidateSet("Error","Warn","Info","Debug")][string]$Level = "Info"
     )
 
     Begin {
@@ -31,6 +31,10 @@ Function Write-Log {
             'Info' {
                 $LevelText = 'INFO:'
                 Write-Host -ForegroundColor DarkCyan -Object "$date $LevelText $Message"
+            }
+            'Debug' {
+                $LevelText = 'DEBUG:'
+                Write-Host -ForegroundColor Gray -Object "$date $LevelText $Message"
             }
         }
         "$date $LevelText $Message" | Out-File -FilePath $filename -Append

--- a/Include.psm1
+++ b/Include.psm1
@@ -19,6 +19,8 @@ Function Write-Log {
         $filename = ".\Logs\MultiPoolMiner-$(Get-Date -Format "yyyy-MM-dd").txt"
         $date = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
 
+        if (-not (Test-Path "Stats")) {New-Item "Stats" -ItemType "directory" | Out-Null}
+        
         switch($Level) {
             'Error' {
                 $LevelText = 'ERROR:'

--- a/Include.psm1
+++ b/Include.psm1
@@ -22,31 +22,23 @@ Function Write-Log {
         switch($Level) {
             'Error' {
                 $LevelText = 'ERROR:'
-                if($ErrorActionPreference -ne 'SilentlyContinue') {
-                    Write-Host -ForegroundColor Red -Object "$date $LevelText $Message"
-                }
+                Write-Error -Message $Message
             }
             'Warn' {
                 $LevelText = 'WARNING:'
-                if($WarningPreference -ne 'SilentlyContinue') {
-                    Write-Host -ForegroundColor Yellow -Object "$date $LevelText $Message"
-                }
+                Write-Warning -Message $Message
             }
             'Info' {
                 $LevelText = 'INFO:'
-                Write-Host -ForegroundColor DarkCyan -Object "$date $LevelText $Message"
+                Write-Information -MessageData $Message
             }
             'Verbose' {
                 $LevelText = 'VERBOSE:'
-                if($VerbosePreference -ne 'SilentlyContinue') {
-                    Write-Host -ForegroundColor Cyan -Object "$date $LevelText $Message"
-                }
+                Write-Verbose -Message $Message
             }
             'Debug' {
                 $LevelText = 'DEBUG:'
-                if($DebugPreference -ne 'SilentlyContinue') {
-                    Write-Host -ForegroundColor Gray -Object "$date $LevelText $Message"
-                }
+                Write-Debug -Message $Message
             }
         }
         "$date $LevelText $Message" | Out-File -FilePath $filename -Append

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -1,5 +1,5 @@
 ﻿using module .\Include.psm1
-
+[CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
     [String]$Wallet, 

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -472,7 +472,7 @@ while ($true) {
     Start-Sleep $Delay #Wait to prevent BSOD
     $ActiveMiners | Where-Object Best -EQ $true | ForEach-Object {
         if ($_.Process -eq $null -or $_.Process.HasExited -ne $false) {
-            Write-Log "Starting $($_.Type) miner $($_.Name) $($_.Arguments)"
+            Write-Log "Starting $($_.Type) miner $($_.Name): '$($_.Path) $($_.Arguments)'"
             $DecayStart = $Timer
             $_.New = $true
             $_.Activated++

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -437,13 +437,15 @@ while ($true) {
         $Miner = $_
 
         if ($Miner.Process -eq $null -or $Miner.Process.HasExited) {
-            if($Miner.Process -eq $null) {
-                Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process handle is missing"
+            if ($Miner.Status -eq "Running") {
+                $Miner.Status = "Failed"
+                if($Miner.Process -eq $null) {
+                    Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process handle is missing"
+                }
+                if($Miner.Process.HasExited) {
+                    Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process exited on it's own"
+                }
             }
-            if($Miner.Process.HasExited) {
-                Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process exited on it's own"
-            }
-            if ($Miner.Status -eq "Running") {$Miner.Status = "Failed"}
         }
         else {
             Write-Log "Closing $($Miner.Type) miner $($Miner.Name) because it is no longer the most profitable"

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -448,7 +448,7 @@ while ($true) {
             }
         }
         else {
-            Write-Log "Closing $($Miner.Type) miner $($Miner.Name) because it is no longer the most profitable"
+            Write-Log "Closing $($Miner.Type) miner $($Miner.Name) [PID $($_.Process.Id)] because it is no longer the most profitable"
             $Miner.Process.CloseMainWindow() | Out-Null
             $Miner.Status = "Idle"
 
@@ -482,7 +482,7 @@ while ($true) {
             else {$_.Process = Start-SubProcess -FilePath $_.Path -ArgumentList $_.Arguments -WorkingDirectory (Split-Path $_.Path) -Priority ($_.Type | ForEach-Object {if ($_ -eq "CPU") {-2}else {-1}} | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum)}
             if ($_.Process -eq $null) {$_.Status = "Failed"}
             else {$_.Status = "Running"}
-            Write-Log "Started $($_.Type) miner $($_.Name) with PID $($_.Process.Id)"
+            Write-Log "Started $($_.Type) miner $($_.Name) [PID $($_.Process.Id)]"
 
             #Add watchdog timer
             if ($Watchdog -and $_.Profit -ne $null) {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -125,7 +125,7 @@ while ($true) {
 
     #Update the exchange rates
     try {
-		Write-Log "Updating exchange rates from Coinbase..."
+        Write-Log "Updating exchange rates from Coinbase..."
         $NewRates = Invoke-RestMethod "https://api.coinbase.com/v2/exchange-rates?currency=BTC" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop | Select-Object -ExpandProperty data | Select-Object -ExpandProperty rates
         $Currency | Where-Object {$NewRates.$_} | ForEach-Object {$Rates | Add-Member $_ ([Double]$NewRates.$_) -Force}
     }
@@ -134,19 +134,19 @@ while ($true) {
     }
 
     #Load the stats
-	Write-Log "Loading saved statistics..."
+    Write-Log "Loading saved statistics..."
     $Stats = [PSCustomObject]@{}
     if (Test-Path "Stats") {Get-ChildItemContent "Stats" | ForEach-Object {$Stats | Add-Member $_.Name $_.Content}}
 
     #Load information about the pools
-	Write-Log "Loading pool information..."
+    Write-Log "Loading pool information..."
     $NewPools = @()
     if (Test-Path "Pools") {
         $NewPools = Get-ChildItemContent "Pools" -Parameters @{Wallet = $Wallet; UserName = $UserName; WorkerName = $WorkerName; StatSpan = $StatSpan} | ForEach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
     }
-	
-	# This finds any pools that were already in $AllPools (from a previous loop) but not in $NewPools. Add them back to the list. Their API likely didn't return in time, but we don't want to cut them off just yet
-	# since mining is probably still working.  Then it filters out any algorithms that aren't being used.
+
+    # This finds any pools that were already in $AllPools (from a previous loop) but not in $NewPools. Add them back to the list. Their API likely didn't return in time, but we don't want to cut them off just yet
+    # since mining is probably still working.  Then it filters out any algorithms that aren't being used.
     $AllPools = @($NewPools) + @(Compare-Object @($NewPools | Select-Object -ExpandProperty Name -Unique) @($AllPools | Select-Object -ExpandProperty Name -Unique) | Where-Object SideIndicator -EQ "=>" | Select-Object -ExpandProperty InputObject | ForEach-Object {$AllPools | Where-Object Name -EQ $_}) | 
         Where-Object {$Algorithm.Count -eq 0 -or (Compare-Object $Algorithm $_.Algorithm -IncludeEqual -ExcludeDifferent | Measure-Object).Count -gt 0} | 
         Where-Object {$ExcludeAlgorithm.Count -eq 0 -or (Compare-Object $ExcludeAlgorithm $_.Algorithm -IncludeEqual -ExcludeDifferent | Measure-Object).Count -eq 0}
@@ -182,10 +182,10 @@ while ($true) {
 
     #Load information about the miners
     #Messy...?
-	Write-Log "Getting miner information..."
-	# Get all the miners, get just the .Content property and add the name, select only the ones that match our $Type (CPU, AMD, NVIDIA) or all of them if type is unset,
-	# select only the ones that have a HashRate matching our algorithms, and that only include algorithms we have pools for
-	# select only the miners that match $MinerName, if specified, and don't match $ExcludeMinerName
+    Write-Log "Getting miner information..."
+    # Get all the miners, get just the .Content property and add the name, select only the ones that match our $Type (CPU, AMD, NVIDIA) or all of them if type is unset,
+    # select only the ones that have a HashRate matching our algorithms, and that only include algorithms we have pools for
+    # select only the miners that match $MinerName, if specified, and don't match $ExcludeMinerName
     $AllMiners = if (Test-Path "Miners") {
         Get-ChildItemContent "Miners" -Parameters @{Pools = $Pools; Stats = $Stats} | ForEach-Object {$_.Content | Add-Member Name $_.Name -PassThru} | 
             Where-Object {$Type.Count -eq 0 -or (Compare-Object $Type $_.Type -IncludeEqual -ExcludeDifferent | Measure-Object).Count -gt 0} | 
@@ -194,7 +194,7 @@ while ($true) {
             Where-Object {$MinerName.Count -eq 0 -or (Compare-Object $MinerName $_.Name -IncludeEqual -ExcludeDifferent | Measure-Object).Count -gt 0} | 
             Where-Object {$ExcludeMinerName.Count -eq 0 -or (Compare-Object $ExcludeMinerName $_.Name -IncludeEqual -ExcludeDifferent | Measure-Object).Count -eq 0}
     }
-	Write-Log "Calculating profit for each miner..."
+    Write-Log "Calculating profit for each miner..."
     $AllMiners | ForEach-Object {
         $Miner = $_
 
@@ -437,16 +437,16 @@ while ($true) {
         $Miner = $_
 
         if ($Miner.Process -eq $null -or $Miner.Process.HasExited) {
-			if($Miner.Process -eq $null) {
-				Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process handle is missing"
-			}
-			if($Miner.Process.HasExited) {
-				Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process exited on it's own"
-			}
+            if($Miner.Process -eq $null) {
+                Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process handle is missing"
+            }
+            if($Miner.Process.HasExited) {
+                Write-Log -Level Warn "$($Miner.Type) miner $($Miner.Name) failed - process exited on it's own"
+            }
             if ($Miner.Status -eq "Running") {$Miner.Status = "Failed"}
         }
         else {
-			Write-Log "Closing $($Miner.Type) miner $($Miner.Name) because it is no longer the most profitable"
+            Write-Log "Closing $($Miner.Type) miner $($Miner.Name) because it is no longer the most profitable"
             $Miner.Process.CloseMainWindow() | Out-Null
             $Miner.Status = "Idle"
 
@@ -470,7 +470,7 @@ while ($true) {
     Start-Sleep $Delay #Wait to prevent BSOD
     $ActiveMiners | Where-Object Best -EQ $true | ForEach-Object {
         if ($_.Process -eq $null -or $_.Process.HasExited -ne $false) {
-			Write-Log "Starting $($_.Type) miner $($_.Name) $($_.Arguments)"
+            Write-Log "Starting $($_.Type) miner $($_.Name) $($_.Arguments)"
             $DecayStart = $Timer
             $_.New = $true
             $_.Activated++
@@ -480,7 +480,7 @@ while ($true) {
             else {$_.Process = Start-SubProcess -FilePath $_.Path -ArgumentList $_.Arguments -WorkingDirectory (Split-Path $_.Path) -Priority ($_.Type | ForEach-Object {if ($_ -eq "CPU") {-2}else {-1}} | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum)}
             if ($_.Process -eq $null) {$_.Status = "Failed"}
             else {$_.Status = "Running"}
-			Write-Log "Started $($_.Type) miner $($_.Name) with PID $($_.Process.Id)"
+            Write-Log "Started $($_.Type) miner $($_.Name) with PID $($_.Process.Id)"
 
             #Add watchdog timer
             if ($Watchdog -and $_.Profit -ne $null) {
@@ -563,7 +563,7 @@ while ($true) {
     [GC]::Collect()
 
     #Do nothing for a few seconds as to not overload the APIs and display miner download status
-	Write-Log "Waiting for $Interval seconds to start next run"
+    Write-Log "Waiting for $Interval seconds to start next run"
     for ($i = $Strikes; $i -gt 0 -or $Timer -lt $StatEnd; $i--) {
         if ($Downloader) {$Downloader | Receive-Job}
         Start-Sleep 10
@@ -571,7 +571,7 @@ while ($true) {
     }
 
     #Save current hash rates
-	Write-Log "Saving hash rates..."
+    Write-Log "Saving hash rates..."
     $ActiveMiners | ForEach-Object {
         $Miner = $_
         $Miner.Speed_Live = 0
@@ -607,7 +607,7 @@ while ($true) {
             }
         }
     }
-	Write "Starting next run..."
+    Write-Log "Starting next run..."
 }
 
 #Stop the log

--- a/Pools/AHashPool.ps1
+++ b/Pools/AHashPool.ps1
@@ -8,12 +8,12 @@ try {
     $AHashPool_Request = Invoke-RestMethod "http://www.ahashpool.com/api/status" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Warning "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
     return
 }
 
 if (($AHashPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
-    Write-Warning "Pool API ($Name) returned nothing. "
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
     return
 }
 

--- a/Pools/Hashrefinery.ps1
+++ b/Pools/Hashrefinery.ps1
@@ -8,12 +8,12 @@ try {
     $HashRefinery_Request = Invoke-RestMethod "http://pool.hashrefinery.com/api/status" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Warning "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
     return
 }
 
 if (($HashRefinery_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
-    Write-Warning "Pool API ($Name) returned nothing. "
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
     return
 }
 

--- a/Pools/MiningPoolHub.ps1
+++ b/Pools/MiningPoolHub.ps1
@@ -8,12 +8,12 @@ try {
     $MiningPoolHub_Request = Invoke-RestMethod "http://miningpoolhub.com/index.php?page=api&action=getautoswitchingandprofitsstatistics" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Warning "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
     return
 }
 
 if (($MiningPoolHub_Request.return | Measure-Object).Count -le 1) {
-    Write-Warning "Pool API ($Name) returned nothing. "
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
     return
 }
 

--- a/Pools/MiningPoolHubCoins.ps1
+++ b/Pools/MiningPoolHubCoins.ps1
@@ -8,12 +8,12 @@ try {
     $MiningPoolHubCoins_Request = Invoke-RestMethod "http://miningpoolhub.com/index.php?page=api&action=getminingandprofitsstatistics" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Warning "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
     return
 }
 
 if (($MiningPoolHubCoins_Request.return | Measure-Object).Count -le 1) {
-    Write-Warning "Pool API ($Name) returned nothing. "
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
     return
 }
 

--- a/Pools/NiceHash.ps1
+++ b/Pools/NiceHash.ps1
@@ -8,12 +8,12 @@ try {
     $NiceHash_Request = Invoke-RestMethod "http://api.nicehash.com/api?method=simplemultialgo.info" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Warning "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
     return
 }
 
 if (($NiceHash_Request.result.simplemultialgo | Measure-Object).Count -le 1) {
-    Write-Warning "Pool API ($Name) returned nothing. "
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
     return
 }
 

--- a/Pools/Zpool.ps1
+++ b/Pools/Zpool.ps1
@@ -8,12 +8,12 @@ try {
     $Zpool_Request = Invoke-RestMethod "http://www.zpool.ca/api/status" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Warning "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
     return
 }
 
 if (($Zpool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
-    Write-Warning "Pool API ($Name) returned nothing. "
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
     return
 }
 


### PR DESCRIPTION
![image 4](https://user-images.githubusercontent.com/669579/34320431-5348af5c-e7c8-11e7-81c6-c10d1e177ca2.png)

This adds a new function Write-Log, which displays messages with a timestamp and error level, and also writes them to a file which is rotated each day.  Write-Log is used instead of Write-Error, Write-Warning, and Write-Verbose.

The lack of timestamps in the existing transcript log was frustrating me.  Sometimes it's important to know exactly when things started going wrong.  This makes logs that are much easier to read.  It also makes issues easier to find, just searching the log file for "WARNING" or "ERROR".

I still left the transcript version logs in, because they will still contain any other uncaught errors.