### PR TITLE
Fix 0 H/s being reported in petahashes

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -207,6 +207,7 @@ filter ConvertTo-Hash {
     [CmdletBinding()]
     $Hash = $_
     switch ([math]::truncate([math]::log($Hash, [Math]::Pow(1000, 1)))) {
+	"-Infinity" {"0 H"}
         0 {"{0:n2}  H" -f ($Hash / [Math]::Pow(1000, 0))}
         1 {"{0:n2} KH" -f ($Hash / [Math]::Pow(1000, 1))}
         2 {"{0:n2} MH" -f ($Hash / [Math]::Pow(1000, 2))}


### PR DESCRIPTION
For 0, the [math] functions return [double]::NegativeInfinity
Switch converts it to a string as "-Infinity"

Since that didn't match any of the options, 0 always got reported as the
default PH.  This adds a case for it and reports it as 0 H.