### PR TITLE
Add feature to set zpool payout currency.

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -44,7 +44,9 @@ param(
     [Parameter(Mandatory = $false)]
     [String]$MinerStatusURL,
     [Parameter(Mandatory = $false)]
-    [Int]$SwitchingPrevention = 1 #zero does not prevent miners switching
+    [Int]$SwitchingPrevention = 1, #zero does not prevent miners switching
+    [Parameter(Mandatory = $false)]
+    [String]$ZpoolCurrency = "BTC"  #currency for zpool payouts
 )
 
 Set-Location (Split-Path $MyInvocation.MyCommand.Path)
@@ -139,7 +141,7 @@ while ($true) {
     #Load information about the pools
     $NewPools = @()
     if (Test-Path "Pools") {
-        $NewPools = Get-ChildItemContent "Pools" -Parameters @{Wallet = $Wallet; UserName = $UserName; WorkerName = $WorkerName; StatSpan = $StatSpan} | ForEach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
+        $NewPools = Get-ChildItemContent "Pools" -Parameters @{Wallet = $Wallet; UserName = $UserName; WorkerName = $WorkerName; StatSpan = $StatSpan; ZpoolCurrency = $ZpoolCurrency} | ForEach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
     }
     $AllPools = @($NewPools) + @(Compare-Object @($NewPools | Select-Object -ExpandProperty Name -Unique) @($AllPools | Select-Object -ExpandProperty Name -Unique) | Where-Object SideIndicator -EQ "=>" | Select-Object -ExpandProperty InputObject | ForEach-Object {$AllPools | Where-Object Name -EQ $_}) | 
         Where-Object {$Algorithm.Count -eq 0 -or (Compare-Object $Algorithm $_.Algorithm -IncludeEqual -ExcludeDifferent | Measure-Object).Count -gt 0} | 

--- a/Pools/Zpool.ps1
+++ b/Pools/Zpool.ps1
@@ -58,7 +58,7 @@ $Zpool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Selec
                 Host          = "$Zpool_Algorithm.$Zpool_Host"
                 Port          = $Zpool_Port
                 User          = $Wallet
-                Pass          = "$WorkerName,c=BTC"
+                Pass          = "$WorkerName,c=$ZpoolCurrency"
                 Region        = $Zpool_Region_Norm
                 SSL           = $false
                 Updated       = $Stat.Updated


### PR DESCRIPTION
Add a way to set the desired zpool payout currency via a new command line parameter named "ZpoolCurrency". There might be better names for the parameter, so feel free to change it.