### PR TITLE
Skip algos with 0 hashrate at pool

### DIFF
--- a/Pools/AHashPool.ps1
+++ b/Pools/AHashPool.ps1
@@ -19,7 +19,7 @@ if (($AHashPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignor
 
 $AHashPool_Regions = "us"
 
-$AHashPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | ForEach-Object {
+$AHashPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$AHashPool_Request.$_.hashrate -gt 0} | ForEach-Object {
     $AHashPool_Host = "mine.ahashpool.com"
     $AHashPool_Port = $AHashPool_Request.$_.port
     $AHashPool_Algorithm = $AHashPool_Request.$_.name

--- a/Pools/Blockmunch.ps1
+++ b/Pools/Blockmunch.ps1
@@ -19,7 +19,7 @@ if (($Blockmunch_Request | Get-Member -MemberType NoteProperty -ErrorAction Igno
 
 $Blockmunch_Regions = "us"
 
-$Blockmunch_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | ForEach-Object {
+$Blockmunch_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$Blockmunch_Request.$_.hashrate -gt 0} | ForEach-Object {
     $Blockmunch_Host = "blockmunch.club"
     $Blockmunch_Port = $Blockmunch_Request.$_.port
     $Blockmunch_Algorithm = $Blockmunch_Request.$_.name
@@ -66,3 +66,4 @@ $Blockmunch_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | 
         }
     }
 }
+Sleep 0

--- a/Pools/Hashrefinery.ps1
+++ b/Pools/Hashrefinery.ps1
@@ -19,7 +19,7 @@ if (($HashRefinery_Request | Get-Member -MemberType NoteProperty -ErrorAction Ig
 
 $HashRefinery_Regions = "us"
 
-$HashRefinery_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | ForEach-Object {
+$HashRefinery_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$Hashrefinery_Request.$_.hashrate -gt 0} | ForEach-Object {
     $HashRefinery_Host = "hashrefinery.com"
     $HashRefinery_Port = $HashRefinery_Request.$_.port
     $HashRefinery_Algorithm = $HashRefinery_Request.$_.name

--- a/Pools/ItalYiiMP.ps1
+++ b/Pools/ItalYiiMP.ps1
@@ -19,7 +19,7 @@ if (($ItalYiiMP_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignor
 
 $ItalYiiMP_Regions = "us"
 
-$ItalYiiMP_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$ItalYiiMP_Request.$_.hashrate -gt 0}| ForEach-Object {
+$ItalYiiMP_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$ItalYiiMP_Request.$_.hashrate -gt 0} | ForEach-Object {
     $ItalYiiMP_Host = "mine.italyiimp.com"
     $ItalYiiMP_Port = $ItalYiiMP_Request.$_.port
     $ItalYiiMP_Algorithm = $ItalYiiMP_Request.$_.name

--- a/Pools/ItalYiiMP.ps1
+++ b/Pools/ItalYiiMP.ps1
@@ -19,7 +19,7 @@ if (($ItalYiiMP_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignor
 
 $ItalYiiMP_Regions = "us"
 
-$ItalYiiMP_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | ForEach-Object {
+$ItalYiiMP_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$ItalYiiMP_Request.$_.hashrate -gt 0}| ForEach-Object {
     $ItalYiiMP_Host = "mine.italyiimp.com"
     $ItalYiiMP_Port = $ItalYiiMP_Request.$_.port
     $ItalYiiMP_Algorithm = $ItalYiiMP_Request.$_.name

--- a/Pools/MiningPoolHub.ps1
+++ b/Pools/MiningPoolHub.ps1
@@ -19,7 +19,7 @@ if (($MiningPoolHub_Request.return | Measure-Object).Count -le 1) {
 
 $MiningPoolHub_Regions = "europe", "us", "asia"
 
-$MiningPoolHub_Request.return | ForEach-Object {
+$MiningPoolHub_Request.return | Where-Object {$MiningPoolHub_Request.$_.hashrate -gt 0} | ForEach-Object {
     $MiningPoolHub_Hosts = $_.all_host_list.split(";")
     $MiningPoolHub_Port = $_.algo_switch_port
     $MiningPoolHub_Algorithm = $_.algo

--- a/Pools/MiningPoolHubCoins.ps1
+++ b/Pools/MiningPoolHubCoins.ps1
@@ -19,7 +19,7 @@ if (($MiningPoolHubCoins_Request.return | Measure-Object).Count -le 1) {
 
 $MiningPoolHubCoins_Regions = "europe", "us", "asia"
 
-$MiningPoolHubCoins_Request.return | ForEach-Object {
+$MiningPoolHubCoins_Request.return | Where-Object {$_.pool_hash -gt 0} |ForEach-Object {
     $MiningPoolHubCoins_Hosts = $_.host_list.split(";")
     $MiningPoolHubCoins_Port = $_.port
     $MiningPoolHubCoins_Algorithm = $_.algo

--- a/Pools/Zpool.ps1
+++ b/Pools/Zpool.ps1
@@ -19,7 +19,7 @@ if (($Zpool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | 
 
 $Zpool_Regions = "us"
 
-$Zpool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | ForEach-Object {
+$Zpool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$Zpool_Request.$_.hashrate -gt 0} |ForEach-Object {
     $Zpool_Host = "mine.zpool.ca"
     $Zpool_Port = $Zpool_Request.$_.port
     $Zpool_Algorithm = $Zpool_Request.$_.name


### PR DESCRIPTION
Add filter to exclude all algos where the pool reports 0 hashrate.
2 reasons for this:
a) This will avoid errors where MPM will try to mine a coin/algo that is not minable (in my tests these algos where dead at the pool)
b) There is little point in 'solo mining' (because I'll be the only one)

Note: Not all pools send hash rates in web request

Here is an example where the current code will attempt to mine lyrav2, the miner will then fail.

![deadalgoonpool](https://user-images.githubusercontent.com/30080938/34638971-1ae4692a-f2d7-11e7-95ca-08a9bad8aa84.png)