### PR TITLE
Remove redundant code in MiningPoolHubCoins

### DIFF
--- a/Pools/MiningPoolHubCoins.ps1
+++ b/Pools/MiningPoolHubCoins.ps1
@@ -87,24 +87,6 @@ $MiningPoolHubCoins_Request.return | Where-Object {$_.pool_hash -gt 0} |ForEach-
                     SSL           = $false
                     Updated       = $Stat.Updated
                 }
-
-                if ($MiningPoolHubCoins_Algorithm_Norm -eq "Cryptonight" -or $MiningPoolHubCoins_Algorithm_Norm -eq "Equihash") {
-                    [PSCustomObject]@{
-                        Algorithm     = "$($MiningPoolHubCoins_Algorithm_Norm)2gb"
-                        Info          = $MiningPoolHubCoins_Coin
-                        Price         = $Stat.Live
-                        StablePrice   = $Stat.Week
-                        MarginOfError = $Stat.Week_Fluctuation
-                        Protocol      = "stratum+ssl"
-                        Host          = $MiningPoolHubCoins_Hosts | Sort-Object -Descending {$_ -ilike "$MiningPoolHubCoins_Region*"} | Select-Object -First 1
-                        Port          = $MiningPoolHubCoins_Port
-                        User          = "$UserName.$WorkerName"
-                        Pass          = "x"
-                        Region        = $MiningPoolHubCoins_Region_Norm
-                        SSL           = $true
-                        Updated       = $Stat.Updated
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
The code checks for Cryptonight or Equihash (for secure stratum) inside an if block that only matches Ethash2gb coins.