### PR TITLE
Use status key instead of BTC address

### DIFF
--- a/Config.txt
+++ b/Config.txt
@@ -55,5 +55,6 @@
   "Delay": "$Delay",
   "Watchdog": "$Watchdog",
   "MinerStatusURL": "$MinerStatusURL",
+  "MinerStatusKey": "$MinerStatusKey",
   "SwitchingPrevention": "$SwitchingPrevention"
 }

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -148,6 +148,10 @@ while ($true) {
             SwitchingPrevention = $SwitchingPrevention
         }
     }
+
+    # For backwards compatibility, set the MinerStatusKey to $Wallet if it's not specified
+    if($Wallet -and -not $Config.MinerStatusKey) { $Config.MinerStatusKey = $Wallet }
+
     Get-ChildItem "Pools" | Where-Object {-not $Config.Pools.($_.BaseName)} | ForEach-Object {
         $Config.Pools | Add-Member $_.BaseName (
             [PSCustomObject]@{

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -54,6 +54,8 @@ param(
     [Alias("Uri", "Url")]
     [String]$MinerStatusUrl = "https://multipoolminer.io/monitor/miner.php",
     [Parameter(Mandatory = $false)]
+    [String]$MinerStatusKey = "",
+    [Parameter(Mandatory = $false)]
     [Double]$SwitchingPrevention = 1 #zero does not prevent miners switching
 )
 
@@ -118,6 +120,7 @@ while ($true) {
             Delay               = $Delay
             Watchdog            = $Watchdog
             MinerStatusURL      = $MinerStatusURL
+            MinerStatusKey      = $MinerStatusKey
             SwitchingPrevention = $SwitchingPrevention
         } | Select-Object -ExpandProperty Content
     }
@@ -141,6 +144,7 @@ while ($true) {
             Delay               = $Delay
             Watchdog            = $Watchdog
             MinerStatusURL      = $MinerStatusURL
+            MinerStatusKey      = $MinerStatusKey
             SwitchingPrevention = $SwitchingPrevention
         }
     }
@@ -577,7 +581,7 @@ while ($true) {
         }
     }
 
-    if ($Config.MinerStatusURL) {& .\ReportStatus.ps1 -Address $Wallet -WorkerName $WorkerName -ActiveMiners $ActiveMiners -Miners $Miners -MinerStatusURL $Config.MinerStatusURL}
+    if ($Config.MinerStatusURL -and $Config.MinerStatusKey) {& .\ReportStatus.ps1 -Key $Config.MinerStatusKey -WorkerName $WorkerName -ActiveMiners $ActiveMiners -Miners $Miners -MinerStatusURL $Config.MinerStatusURL}
 
     #Display mining information
     $Miners | Where-Object {$_.Profit -ge 1E-5 -or $_.Profit -eq $null} | Sort-Object -Descending Type, Profit_Bias | Format-Table -GroupBy Type (

--- a/ReportStatus.ps1
+++ b/ReportStatus.ps1
@@ -1,7 +1,7 @@
 ﻿using module .\Include.psm1
 
 param(
-    [Parameter(Mandatory=$true)][String]$Address,
+    [Parameter(Mandatory=$true)][String]$Key,
     [Parameter(Mandatory=$true)][String]$WorkerName,
     [Parameter(Mandatory=$true)]$ActiveMiners,
     [Parameter(Mandatory=$true)]$Miners,
@@ -30,4 +30,4 @@ $minerreport = ConvertTo-Json @($ActiveMiners | Where-Object {$_.Activated -GT 0
         'BTC/day' = $_.Profit
     }
 })
-Invoke-RestMethod -Uri $MinerStatusURL -Method Post -Body @{address = $Address; workername = $WorkerName; miners = $minerreport; profit = $profit}
+Invoke-RestMethod -Uri $MinerStatusURL -Method Post -Body @{address = $Key; workername = $WorkerName; miners = $minerreport; profit = $profit}

--- a/ReportStatus.ps1
+++ b/ReportStatus.ps1
@@ -31,3 +31,4 @@ $minerreport = ConvertTo-Json @($ActiveMiners | Where-Object {$_.Activated -GT 0
     }
 })
 Invoke-RestMethod -Uri $MinerStatusURL -Method Post -Body @{address = $Key; workername = $WorkerName; miners = $minerreport; profit = $profit}
+Write-Host "Your miner status key is: $Key"


### PR DESCRIPTION
Adds a miner status key to the new config.txt file.  Removes the requirement for having a bitcoin address from the website.

Website has also been modified to generate these status keys for new users.

You can still use your bitcoin address as your status key if you prefer, so existing users can keep using their address as the status key without changing anything.