### PR TITLE
Filter files beginning with _

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -213,7 +213,7 @@ function Get-ChildItemContent {
         return $Expression
     }
 
-    Get-ChildItem $Path | ForEach-Object {
+    Get-ChildItem $Path -Exclude "_*" | ForEach-Object {
         $Name = $_.BaseName
         $Content = @()
         if ($_.Extension -eq ".ps1") {


### PR DESCRIPTION
Better than deleting the files. Works for folder and file names.
Should be included in documentation