### PR TITLE
Tiny bugfix: Escape variable in write-log line

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -640,7 +640,7 @@ while ($true) {
     [GC]::Collect()
 
     #Do nothing for a few seconds as to not overload the APIs and display miner download status
-    Write-Log "Waiting for $Config.Interval seconds to start next run"
+    Write-Log "Waiting for $($Config.Interval) seconds to start next run"
     for ($i = $Strikes; $i -gt 0 -or $Timer -lt $StatEnd; $i--) {
         if ($Downloader) {$Downloader | Receive-Job}
         Start-Sleep 10


### PR DESCRIPTION
$Config.Interval needs to be wrapped in $() or it dumps all of $Config to the screen instead of just the interval.