### PR TITLE
OpenGL: Suppress error on empty query result

### DIFF
--- a/OpenCL/Device.cs
+++ b/OpenCL/Device.cs
@@ -397,9 +397,9 @@ namespace OpenCl
 
             var ids = new IntPtr[count] ;
             error = NativeMethods.clGetDeviceIDs(platform.handle, type, count, ids, out count);
-            if (error != ErrorCode.Success) {
-                throw new OpenClException(error);
-            }
+//            if (error != ErrorCode.Success) {
+//                throw new OpenClException(error);
+//            }
 
             var res = new Device[count];
             for (var i=0; i<count; i++) {

--- a/OpenCL/Platform.cs
+++ b/OpenCL/Platform.cs
@@ -61,9 +61,9 @@ namespace OpenCl
             uint count;
 
             error = NativeMethods.clGetPlatformIDs(0, null, out count);
-            if (error != ErrorCode.Success) {
-                throw new OpenClException(error);
-            }
+//            if (error != ErrorCode.Success) {
+//                throw new OpenClException(error);
+//            }
 
             var ids = new IntPtr[count] ;
             error = NativeMethods.clGetPlatformIDs(count, ids, out count);


### PR DESCRIPTION
The current OpenGL implementation throws an error if no Gpu's for the given platform are found.
E.g. I dont have AMD hardware:
[OpenCl.Platform]::GetPlatformIDs() | Where-Object {$_.Vendor -eq 'Advanced Micro Devices, Inc.'} | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::Gpu)}
Exception calling "GetDeviceIDs" with "2" argument(s): "OpenCl error -1: DeviceNotFound."
At line:1 char:110
+ ... ach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::Gp ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : OpenClException

The requested change helps optimizing some OpenGL calls.

We can optimize the code from
[OpenCl.Platform]::GetPlatformIDs() | Where-Object {$_.Vendor -eq 'Advanced Micro Devices, Inc.'} | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where-Object {$_.Type -eq "Gpu"}

to this:
[OpenCl.Platform]::GetPlatformIDs() | Where-Object {$_.Vendor -eq 'Advanced Micro Devices, Inc.'} | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::Gpu)}