### PR TITLE
Exlude pools listed in ExcludePoolName

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -166,6 +166,12 @@ while ($true) {
             }
         )
     }
+
+    # Remove configuration for pools specified in ExcludePoolName
+    if($Config.ExcludePoolName) {
+        $Config.ExcludePoolName | Foreach-Objecct { $Config.Pools.PSObject.Properties.Remove($_) }
+    }
+
     Get-ChildItem "Miners" | Where-Object {-not $Config.Miners.($_.BaseName)} | ForEach-Object {
         $Config.Miners | Add-Member $_.BaseName (
             [PSCustomObject]@{
@@ -223,7 +229,7 @@ while ($true) {
     Write-Log "Loading pool information..."
     $NewPools = @()
     if (Test-Path "Pools") {
-        $NewPools = Get-ChildItem "Pools" | ForEach-Object {
+        $NewPools = Get-ChildItem "Pools" | Where-Object {$Config.Pools.$($_.BaseName)} | ForEach-Object {
             $Pool_Name = $_.BaseName
             $Pool_Parameters = @{StatSpan = $StatSpan}
             $Config.Pools.$Pool_Name | Get-Member -MemberType NoteProperty | ForEach-Object {$Pool_Parameters.($_.Name) = $Config.Pools.$Pool_Name.($_.Name)}


### PR DESCRIPTION
This removes the configuration for any pools listed in ExcludePoolName, and alters the script to not load pools without a configuration specified.  With this, if a pool is listed in ExcludePoolName, it really won't be used - even if there are algorithms listed only available on that pool (the current behaviour).

This has a couple advantages:
- Gives you a way to disable a pool without deleting files, which makes it easier to move your configuration from one version to the next. Also makes it easier to change your mind and reenable a pool without having to reextract the required files.
- Donation time can still use any pool that can be configured, even ones people disabled for their own mining.  This may be important if people start only using some of the new pools that don't auto convert, and deleting all the others, so there would be no valid donation pool.  Donation does it's own pool configuration, and remains unaffected by ExcludePoolName.
- Makes the ExcludePoolName switch match the behaviour of the other Exclude<item> switches.  Right now ExcludePoolName is the only one that doesn't really completely exclude them.  This is making it confusing for users (for example: #1096 #891).
- Reduces some of the load on the pool site APIs, since it won't be loading information about pools people don't want to mine to anyways.
- Makes my setup GUI easier to write, since I can give options for each pool as something like "Preferred, Alternative, or Disabled", which is pretty intuitive compared to the current settings.

Resolves #993.

