### PR TITLE
Create separate config file for each miner

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -236,7 +236,12 @@ function Get-ChildItemContent {
             if ($Content -eq $null) {$Content = $_ | Get-Content}
         }
         $Content | ForEach-Object {
-            [PSCustomObject]@{Name = $Name; Content = $_}
+            if ($_.Name) {
+                [PSCustomObject]@{Name = $_.Name; Content = $_}
+            }
+            else {
+                [PSCustomObject]@{Name = $Name; Content = $_}
+            }
         }
     }
 }


### PR DESCRIPTION
So individual customization can be retained when the miner files (not binaries) are updated.

Explanations for changes

include.psm1 lines 236- 244 & MultiPoolMiner.ps1 line 281:

This makes it possible to pass the miner name as part of the JSON structure. This is required if a miner needs to create more than one miner instance, e.g.
- ClaymoreDual with different dcri values
- separate miner instance per GPU platform

MultiPoolMiner.ps1 lines 171 - 176:
Read miner config from separate miner config file. One file per miner. Do not store miner stuff in config.txt

Both changes are a requirement for further miner development