### PR TITLE
DSTM Miner: add --color parameter

### DIFF
--- a/Miners/Dstm.txt
+++ b/Miners/Dstm.txt
@@ -1,7 +1,7 @@
 {
     "Type":  "NVIDIA",
     "Path":  ".\\Bin\\Equihash-DSTM\\zm.exe",
-    "Arguments":  "\"--telemetry --server $(if ($Pools.Equihash.SSL) {'ssl://'})$($Pools.Equihash.Host) --port $($Pools.Equihash.Port) --user $($Pools.Equihash.User) --pass $($Pools.Equihash.Pass)\"",
+    "Arguments":  "\"--telemetry --server $(if ($Pools.Equihash.SSL) {'ssl://'})$($Pools.Equihash.Host) --port $($Pools.Equihash.Port) --user $($Pools.Equihash.User) --pass $($Pools.Equihash.Pass) --color\"",
     "HashRates":  {
                       "Equihash":  "\"$($Stats.Dstm_Equihash_HashRate.Week)\""
                   },


### PR DESCRIPTION
Parameter '--color' is backwards compatible
older versions < 0.6 produce a warning message but continue to work.

Without showing miner windows the miner accepts the parameter, but it says 'color mode not supported' and the resulting text log is 'boring'

I think we should still keep the parameter. It does not do any harm, and should we find a way to display the miner windows again it'll make people happy to see some colors in their lives :-)