### PR TITLE
Bminer: fix for https://github.com/MultiPoolMiner/MultiPoolMiner/issu…

### DIFF
--- a/Miners/BMiner.txt
+++ b/Miners/BMiner.txt
@@ -1,7 +1,7 @@
 {
     "Type":  "NVIDIA",
     "Path":  ".\\Bin\\NVIDIA-BMiner\\BMiner.exe",
-    "Arguments":  "\"-api 127.0.0.1:1880 -uri $(if ($Pools.Equihash.SSL) {'stratum+ssl'}else {'stratum'})://$($Pools.Equihash.User):$($Pools.Equihash.Pass)@$($Pools.Equihash.Host):$($Pools.Equihash.Port) -nofee\"",
+    "Arguments":  "\"-api 127.0.0.1:1880 -uri $(if ($Pools.Equihash.SSL) {'stratum+ssl'}else {'stratum'})://$($Pools.Equihash.User):$($Pools.Equihash.Pass)@$($Pools.Equihash.Host):$($Pools.Equihash.Port) -nofee -watchdog=false\"",
     "HashRates":  {
                       "Equihash":  "\"$($Stats.Bminer_Equihash_HashRate.Week)\""
                   },


### PR DESCRIPTION
…es/1306

bminers watchdog launches multiple instances of bminer which will in turn lead to issue https://github.com/MultiPoolMiner/MultiPoolMiner/issues/1306

Running bminer without watchdog fixes this. There will only be ONE instance of BMINER.