### PR TITLE
Include NetSecurity and Defender modules in main script

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -1,7 +1,4 @@
-﻿Import-Module "$env:Windir\System32\WindowsPowerShell\v1.0\Modules\NetSecurity\NetSecurity.psd1" -ErrorAction Ignore
-Import-Module "$env:Windir\System32\WindowsPowerShell\v1.0\Modules\Defender\Defender.psd1" -ErrorAction Ignore
-
-Set-Location (Split-Path $MyInvocation.MyCommand.Path)
+﻿Set-Location (Split-Path $MyInvocation.MyCommand.Path)
 
 Add-Type -Path .\OpenCL\*.cs
 

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -64,6 +64,8 @@ $Strikes = 3
 $SyncWindow = 5 #minutes
 
 Set-Location (Split-Path $MyInvocation.MyCommand.Path)
+Import-Module NetSecurity -ErrorAction Ignore
+Import-Module Defender -ErrorAction Ignore
 
 $Algorithm = $Algorithm | ForEach-Object {Get-Algorithm $_}
 $ExcludeAlgorithm = $ExcludeAlgorithm | ForEach-Object {Get-Algorithm $_}


### PR DESCRIPTION
This should improve performance a little bit.

They are only used in the main script. Having them imported in
Include.psm1 means they get imported many times by many parts of the
script that don't use them at all.

Also, calling them by name instead of the full path works fine, and fixes issues on Windows Server OS.

Fixes #875