### PR TITLE
Fix for log file getting corrupted

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -14,6 +14,10 @@ Function Write-Log {
 
     Begin { }
     Process {
+        # Get mutex named MPMWriteLog. Mutexes are shared across all threads and processes.
+        # This lets us ensure only one thread is trying to write to the file at a time.
+        $mutex = New-Object System.Threading.Mutex($false, "MPMWriteLog")
+
         $filename = ".\Logs\MultiPoolMiner_$(Get-Date -Format "yyyy-MM-dd").txt"
         $date = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
 
@@ -41,7 +45,14 @@ Function Write-Log {
                 Write-Debug -Message $Message
             }
         }
-        "$date $LevelText $Message" | Out-File -FilePath $filename -Append
+
+        # Attempt to aquire mutex, waiting up to 1 second if necessary.  If aquired, write to the log file and release mutex.  Otherwise, display an error.
+        if($mutex.WaitOne(1000)) {
+            "$date $LevelText $Message" | Out-File -FilePath $filename -Append -Encoding ascii
+            $mutex.ReleaseMutex()
+        } else {
+            Write-Error -Message "Log file is locked, unable to write message to log."
+        }
     }
     End {}
 }


### PR DESCRIPTION
It seems to be a combination of two issues:

One is Out-File sometimes deciding the file is Unicode instead of ASCII, and writing with a space (actually a NUL) between each character (see https://stackoverflow.com/questions/11147179/nul-byte-between-every-other-character-in-output).

This is fixed by adding `-Encoding ascii` to the Out-File command to force the encoding.

The other is a race condition that happens very rarely, corrupting the log file when multiple threads/processes/jobs try to write to the file at exactly the same moment. This one is fixed using mutexes, which are shared between processes, and cause the program to wait up to 1 second for any other programs to release the mutex before writing to the file. In reality, the wait will be much shorter than that, usually 0.  The timeout is just to ensure the program doesn't get stuck there if somehow the mutex didn't get released.

Fixes #1383 