### PR TITLE
Update Include.psm1 to fix downloader Cannot download errors

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -366,6 +366,7 @@ function Expand-WebRequest {
     $FileName = Join-Path ".\Downloads" (Split-Path $Uri -Leaf)
 
     if (Test-Path $FileName) {Remove-Item $FileName}
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest $Uri -OutFile $FileName -UseBasicParsing
 
     if (".msi", ".exe" -contains ([IO.FileInfo](Split-Path $Uri -Leaf)).Extension) {


### PR DESCRIPTION
Add TSLS 1.2 protocol for GITHUB downloads.
Fix downloader errors complaining "cannot download" and "cannot find" under various Windows setups.