### PR TITLE
BMiner.txt: Update to version 5.5

### DIFF
--- a/Miners/BMiner.txt
+++ b/Miners/BMiner.txt
@@ -7,5 +7,5 @@
                   },
     "API":  "Bminer",
     "Port":  "1880",
-    "URI":  "https://www.bminercontent.com/releases/bminer-v5.4.0-ae18e12-amd64.zip"
+    "URI":  "https://www.bminercontent.com/releases/bminer-v5.5.0-aba7617-amd64.zip"
 }


### PR DESCRIPTION
5.5.0 (Current)
Show the fan speed in both console and UI.
Fix compatibility issues for pool.miningspeed.com.
Fix a bug that causes Bminer fails to start on Windows under some configuration.