### PR TITLE
Add logfile path to miner object

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -488,6 +488,7 @@ class Miner {
     hidden [Int]$Activated = 0
     hidden [MinerStatus]$Status = [MinerStatus]::Idle
     $Benchmarked
+    $LogFile
 
     hidden StartMining() {
         $this.Status = [MinerStatus]::Failed
@@ -507,7 +508,8 @@ class Miner {
         }
 
         if (-not $this.Process) {
-            $this.Process = Start-SubProcess -FilePath $this.Path -ArgumentList $this.Arguments -LogPath $Global:ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(".\Logs\$($this.Name)-$($this.Port)_$(Get-Date -Format "yyyy-MM-dd_HH-mm-ss").txt") -WorkingDirectory (Split-Path $this.Path) -Priority ($this.Type | ForEach-Object {if ($_ -eq "CPU") {-2}else {-1}} | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum)
+            $this.LogFile = $Global:ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(".\Logs\$($this.Name)-$($this.Port)_$(Get-Date -Format "yyyy-MM-dd_HH-mm-ss").txt")
+            $this.Process = Start-SubProcess -FilePath $this.Path -ArgumentList $this.Arguments -LogPath $this.LogFile -WorkingDirectory (Split-Path $this.Path) -Priority ($this.Type | ForEach-Object {if ($_ -eq "CPU") {-2}else {-1}} | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum)
 
             if ($this.Process | Get-Job -ErrorAction SilentlyContinue) {
                 $this.Status = [MinerStatus]::Running


### PR DESCRIPTION
Small change @UselessGuru and I discussed in #1345 - adding the log file path to the miner object.

Needed for the API I'm working on, and figured I would PR just this part now since I already have it done and it's such a small easy to review change.

Tested on Windows 10, Powershell Core 6.0.1