### PR TITLE
BlazePool.ps1: Fix worker name display @ pool

### DIFF
--- a/Pools/BlazePool.ps1
+++ b/Pools/BlazePool.ps1
@@ -63,7 +63,7 @@ $BlazePool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | S
                 Host          = $BlazePool_Host
                 Port          = $BlazePool_Port
                 User          = Get-Variable $_ -ValueOnly
-                Pass          = "$Worker,c=$_"
+                Pass          = "ID=$Worker,c=$_"
                 Region        = $BlazePool_Region_Norm
                 SSL           = $false
                 Updated       = $Stat.Updated


### PR DESCRIPTION
Fix for https://github.com/MultiPoolMiner/MultiPoolMiner/issues/1446

BlazePool requires **ID=**[Workername] in the -p parameter