### PR TITLE
CcminerKlausT: Update to version 8.21

### DIFF
--- a/Miners/CcminerKlaust.ps1
+++ b/Miners/CcminerKlaust.ps1
@@ -32,7 +32,6 @@ $Commands = [PSCustomObject]@{
     #"tribus" = "" #Tribus
     #"veltor" = "" #Veltor
     #"x11evo" = "" #X11evo
-    "x16r" = "" #X16r
     #"x17" = "" #X17
     #"yescrypt" = "" #Yescrypt
     #"xevan" = "" #Xevan

--- a/Miners/CcminerKlaust.ps1
+++ b/Miners/CcminerKlaust.ps1
@@ -1,7 +1,7 @@
 ﻿using module ..\Include.psm1
 
 $Path = ".\Bin\NVIDIA-KlausT\ccminer.exe"
-$Uri = "https://github.com/KlausT/ccminer/releases/download/8.20/ccminer-820-cuda91-x64.zip"
+$Uri = "https://github.com/KlausT/ccminer/releases/download/8.21/ccminer-821-cuda91-x64.zip"
 
 $Commands = [PSCustomObject]@{
     #"bitcore" = "" #Bitcore


### PR DESCRIPTION
CcminerKlausT does not support x16R algorithm
Main improvement for MPM users might be the intensity fixes. New options will not be used by current miner implementation.

Fixes:
add option --cuda-schedule
add option --logfile
make ccminer compilable under OSX
Neoscrypt: detect P104-100 and Tesla P100/V100
Lyra2v2: fix verification bug (Linux)
fix for intensities between 8 and 9