### PR TITLE
deviceid and pool compatibility

### DIFF
--- a/Miners/ClaymoreNvidia.txt
+++ b/Miners/ClaymoreNvidia.txt
@@ -2,7 +2,7 @@
     {
         "Type":  "NVIDIA",
         "Path":  ".\\Bin\\Ethash-Claymore\\EthDcrMiner64.exe",
-        "Arguments":  "\"-r -1 -mport -23333 -epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm 3 -allpools 1 -allcoins 1 -platform 2$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where-Object {$_.Type -eq 'GPU' -and $_.Vendor -eq 'NVIDIA Corporation'} | ForEach-Object {if ($_.GlobalMemsize -ge 3000000000) {$DeviceIDs += $DeviceID}; $DeviceID++});if($DeviceIDs){' -di';$($DeviceIDs -join '')})\"",
+        "Arguments":  "\"-r -1 -mport -23333 -epool $($Pools.Ethash.Host):$($Pools.Ethash.Port) -ewal $($Pools.Ethash.User) -epsw $($Pools.Ethash.Pass) -esm $(if($Pools.Ethash.Name -eq 'NiceHash'){3}else{2}) -allpools 1 -allcoins 1 -platform 2$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where-Object {$_.Type -eq 'GPU' -and $_.Vendor -eq 'NVIDIA Corporation'} | ForEach-Object {if ($_.GlobalMemsize -ge 3000000000) {$DeviceIDs += $DeviceID -replace '10', 'a' -replace '11', 'b'}; $DeviceID++});if($DeviceIDs){' -di';$($DeviceIDs -join '')})\"",
         "HashRates":  {
                           "Ethash":  "\"$(if(([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where-Object {$_.Type -eq 'GPU' -and $_.Vendor -eq 'NVIDIA Corporation'} | Where-Object {$_.GlobalMemsize -ge 3000000000}).Count -eq 0) {0} else {$Stats.ClaymoreNvidia_Ethash_HashRate.Week})\""
                       },


### PR DESCRIPTION
proper deviceid for 11th and 12th card
`{$DeviceIDs += $DeviceID -replace '10', 'a' -replace '11', 'b'}`
better pool compatibility, i hope
`$(if($Pools.Ethash.Name -eq 'NiceHash'){3}else{2})`