### PR TITLE
MultiPoolMIner.ps1: Stop on broken config.txt

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -161,6 +161,14 @@ while ($true) {
         }
     }
 
+    #Error in Config.txt
+    if ($Config -isnot [PSCustomObject]) {
+        Write-Log -Level Error "*********************************************************** "
+        Write-Log -Level Error "Critical error: Config.txt is invalid. MPM cannot continue. "
+        Write-Log -Level Error "*********************************************************** "
+        Exit
+    }
+
     #For backwards compatibility, set the MinerStatusKey to $Wallet if it's not specified
     if ($Wallet -and -not $Config.MinerStatusKey) {$Config.MinerStatusKey = $Wallet}
 


### PR DESCRIPTION
New features require editing config.txt.
Incorrectly modified JOSON files have caused quite a number of issues lately.
This PR stops MPM if config.txt is not a valid JSON