### PR TITLE
ZergPool.ps1: Fix $ZergPool_MiningCurrencies

### DIFF
--- a/Pools/ZergPool.ps1
+++ b/Pools/ZergPool.ps1
@@ -28,7 +28,7 @@ if (($ZergPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore
 
 $ZergPool_Regions = "us", "europe"
 $ZergPool_Currencies = @("BTC", "LTC") | Select-Object -Unique | Where-Object {Get-Variable $_ -ValueOnly -ErrorAction SilentlyContinue}
-$ZergPool_MiningCurrencies = ($ZergPoolCoins_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name) | Select-Object -Unique
+$ZergPool_MiningCurrencies = ($ZergPoolCoins_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name) | Foreach-Object {if ($ZergPoolCoins_Request.$_.Symbol) {$ZergPoolCoins_Request.$_.Symbol} else {$_}} | Select-Object -Unique # filter ...-algo
 
 $ZergPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Object -ExpandProperty Name | Where-Object {$ZergPool_Request.$_.hashrate -gt 0} |ForEach-Object {
     $ZergPool_Host = "mine.zergpool.com"


### PR DESCRIPTION
What does this fix???

Some currencies can be mined with multiple algorithms, e.g. "DGB-myr-gr", "DGB-scrypt", "DGB-skein".
This fix removes the invalid ...[-algo] suffix in the currency name.

This fix is also already implemented in this PR: https://github.com/MultiPoolMiner/MultiPoolMiner/pull/1435