### PR TITLE
CcminerNevermore for X16R

### DIFF
--- a/Miners/CcminerNevermore.ps1
+++ b/Miners/CcminerNevermore.ps1
@@ -1,7 +1,7 @@
 ﻿using module ..\Include.psm1
 
 $Path = ".\Bin\NVIDIA-Nevermore\ccminer.exe"
-$Uri = "https://github.com/nemosminer/ccminernevermore/releases/download/0.2-nevermore/ccminernevermore0.2x64.zip"
+$Uri = "https://github.com/brian112358/nevermore-miner/releases/download/v0.2.2/nevermore-v0.2.2-win64.zip"
 
 $Commands = [PSCustomObject]@{
     "x16r"  = "" #X16R RavenCoin

--- a/Miners/CcminerNevermore.ps1
+++ b/Miners/CcminerNevermore.ps1
@@ -5,6 +5,7 @@ $Uri = "https://github.com/brian112358/nevermore-miner/releases/download/v0.2.2/
 
 $Commands = [PSCustomObject]@{
     "x16r"  = "" #X16R RavenCoin
+    "x16s"  = "" #X16S PigeonCoin
 }
 
 $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName

--- a/Miners/CcminerNevermore.ps1
+++ b/Miners/CcminerNevermore.ps1
@@ -1,0 +1,22 @@
+﻿using module ..\Include.psm1
+
+$Path = ".\Bin\NVIDIA-Nevermore\ccminer.exe"
+$Uri = "https://github.com/nemosminer/ccminernevermore/releases/download/0.2-nevermore/ccminernevermore0.2x64.zip"
+
+$Commands = [PSCustomObject]@{
+    "x16r"  = "" #X16R RavenCoin
+}
+
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+
+$Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | Where-Object {$Pools.(Get-Algorithm $_).Protocol -eq "stratum+tcp" <#temp fix#>} | ForEach-Object {
+    [PSCustomObject]@{
+        Type = "NVIDIA"
+        Path = $Path
+        Arguments = "-a $_ -o $($Pools.(Get-Algorithm $_).Protocol)://$($Pools.(Get-Algorithm $_).Host):$($Pools.(Get-Algorithm $_).Port) -u $($Pools.(Get-Algorithm $_).User) -p $($Pools.(Get-Algorithm $_).Pass)$($Commands.$_)"
+        HashRates = [PSCustomObject]@{(Get-Algorithm $_) = $Stats."$($Name)_$(Get-Algorithm $_)_HashRate".Week}
+        API = "Ccminer"
+        Port = 4068
+        URI = $Uri
+    }
+}

--- a/Miners/CcminerNevermore.ps1
+++ b/Miners/CcminerNevermore.ps1
@@ -1,11 +1,12 @@
-﻿using module ..\Include.psm1
+using module ..\Include.psm1
 
 $Path = ".\Bin\NVIDIA-Nevermore\ccminer.exe"
+$HashSHA256 = "1A680F1853F003D8E7D1A957C78B2BE09A47039E2C437A846C71B62CA34BE22E"
 $Uri = "https://github.com/brian112358/nevermore-miner/releases/download/v0.2.2/nevermore-v0.2.2-win64.zip"
 
 $Commands = [PSCustomObject]@{
-    "x16r"  = "" #X16R RavenCoin
-    "x16s"  = "" #X16S PigeonCoin
+    "X16r" = "" #X16r RavenCoin
+    "X16s" = "" #X16s PigeonCoin
 }
 
 $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
@@ -14,10 +15,13 @@ $Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty 
     [PSCustomObject]@{
         Type = "NVIDIA"
         Path = $Path
+        HashSHA256 = $HashSHA256
         Arguments = "-a $_ -o $($Pools.(Get-Algorithm $_).Protocol)://$($Pools.(Get-Algorithm $_).Host):$($Pools.(Get-Algorithm $_).Port) -u $($Pools.(Get-Algorithm $_).User) -p $($Pools.(Get-Algorithm $_).Pass)$($Commands.$_)"
         HashRates = [PSCustomObject]@{(Get-Algorithm $_) = $Stats."$($Name)_$(Get-Algorithm $_)_HashRate".Week}
         API = "Ccminer"
         Port = 4068
         URI = $Uri
+        PrerequisitePath = "$env:SystemRoot\System32\msvcr120.dll"
+        PrerequisiteURI = "http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe"
     }
 }


### PR DESCRIPTION
Miner still triggers watchdog despite of:

v0.2 increase opt_statsavg from 30 seconds to 2 minutes 30 seconds (average out fluctuating x16r hash-rate)

Optimized CCMiner (CUDA miner) fork for x16r

Forked from https://github.com/tpruvot/ccminer
Alexis78 x16r support added by "brian112358" : https://github.com/brian112358/nevermore-miner
disabled fee and recompiled: https://github.com/nemosminer/ccminernevermore

24-hour side-by-side comparison on 1080 Ti show 15-20% increased hash-rate over ccminer/RavenMiner-2.2.5

compiled with vs2013 cuda 9 x64

see here: https://github.com/MultiPoolMiner/MultiPoolMiner/issues/1507

Update: Miner is still faster than latest CcminerSuprMiner 1.5.7