### PR TITLE
Set working directory for API

### DIFF
--- a/API.psm1
+++ b/API.psm1
@@ -10,6 +10,7 @@ Function Start-APIServer {
     $newRunspace = [runspacefactory]::CreateRunspace()
     $newRunspace.Open()
     $newRunspace.SessionStateProxy.SetVariable("API", $API)
+    $newRunspace.SessionStateProxy.Path.SetLocation($(pwd))
 
     $apiserver = [PowerShell]::Create().AddScript({
 


### PR DESCRIPTION
The working directory wasn't being set for the API's runspace.

This made it sometimes unable to find the documentation html file (depends on how it was launched).