### PR TITLE
Add pool name to active miners

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -495,6 +495,7 @@ class Miner {
     hidden [MinerStatus]$Status = [MinerStatus]::Idle
     $Benchmarked
     $LogFile
+    $Pool
 
     hidden StartMining() {
         $this.Status = [MinerStatus]::Failed

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -482,6 +482,7 @@ while ($true) {
                 Best_Comparison      = $false
                 New                  = $false
                 Benchmarked          = 0
+                Pool                 = $Miner.Pools.PSObject.Properties.Value.Name
             }
         }
     }
@@ -616,7 +617,7 @@ while ($true) {
         }
     }
 
-    if ($Config.MinerStatusURL -and $Config.MinerStatusKey) {& .\ReportStatus.ps1 -Key $Config.MinerStatusKey -WorkerName $WorkerName -ActiveMiners $ActiveMiners -Miners $Miners -MinerStatusURL $Config.MinerStatusURL}
+    if ($Config.MinerStatusURL -and $Config.MinerStatusKey) {& .\ReportStatus.ps1 -Key $Config.MinerStatusKey -WorkerName $WorkerName -ActiveMiners $ActiveMiners -MinerStatusURL $Config.MinerStatusURL}
 
     Clear-Host
 

--- a/ReportStatus.ps1
+++ b/ReportStatus.ps1
@@ -4,7 +4,6 @@ param(
     [Parameter(Mandatory = $true)][String]$Key,
     [Parameter(Mandatory = $true)][String]$WorkerName,
     [Parameter(Mandatory = $true)]$ActiveMiners,
-    [Parameter(Mandatory = $true)]$Miners,
     [Parameter(Mandatory = $true)]$MinerStatusURL
 )
 
@@ -14,9 +13,6 @@ $profit = ($ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.Status -eq "
 # Format the miner values for reporting.  Set relative path so the server doesn't store anything personal (like your system username, if running from somewhere in your profile)
 $minerreport = ConvertTo-Json @(
     $ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.Status -eq "Running"} | Foreach-Object {
-        $ActiveMiner = $_
-        # Find the matching entry in $Miners, to get pool information. Perhaps there is a better way to do this?
-        $MatchingMiner = $Miners | Where-Object {$_.Name -eq $ActiveMiner.Name -and $_.Path -eq $ActiveMiner.Path -and $_.Arguments -eq $ActiveMiner.Arguments -and $_.Wrap -eq $ActiveMiner.Wrap -and $_.API -eq $ActiveMiner.API -and $_.Port -eq $ActiveMiner.Port}
         # Create a custom object to convert to json. Type, Pool, CurrentSpeed and EstimatedSpeed are all forced to be arrays, since they sometimes have multiple values.
         [pscustomobject]@{
             Name           = $_.Name
@@ -24,7 +20,7 @@ $minerreport = ConvertTo-Json @(
             Type           = @($_.Type)
             Active         = "{0:dd} Days {0:hh} Hours {0:mm} Minutes" -f $_.GetActiveTime()
             Algorithm      = @($_.Algorithm)
-            Pool           = @($MatchingMiner.Pools.PsObject.Properties.Value.Name)
+            Pool           = @($_.Pool)
             CurrentSpeed   = @($_.Speed_Live)
             EstimatedSpeed = @($_.Speed)
             'BTC/day'      = $_.Profit


### PR DESCRIPTION
This benefits both the monitoring script and API - no longer need to try
to match the miner in $ActiveMiners to the one in $Miners to find the
pool names.