### PR TITLE
Fix ClaymoreCPU port

### DIFF
--- a/Miners/ClaymoreCpu.txt
+++ b/Miners/ClaymoreCpu.txt
@@ -1,11 +1,11 @@
 {
     "Type":  "CPU",
     "Path":  ".\\Bin\\CryptoNight-Claymore-Cpu\\NsCpuCNMiner64.exe",
-    "Arguments":  "\"-r -1 -mport 3333 -o $($Pools.CryptoNight.Protocol)://$($Pools.CryptoNight.Host):$($Pools.CryptoNight.Port) -u $($Pools.CryptoNight.User) -p $($Pools.CryptoNight.Pass)\"",
+    "Arguments":  "\"-r -1 -mport -3333 -o $($Pools.CryptoNight.Protocol)://$($Pools.CryptoNight.Host):$($Pools.CryptoNight.Port) -u $($Pools.CryptoNight.User) -p $($Pools.CryptoNight.Pass)\"",
     "HashRates":  {
                       "CryptoNight":  "\"$($Stats.ClaymoreCPU_CryptoNight_HashRate.Week)\""
                   },
     "API":  "Claymore",
-    "Port":  "-3333",
+    "Port":  "3333",
     "Wrap":  false
 }


### PR DESCRIPTION
Port in Arguments should be negative to prevent remote management. Port
property itself should be positive.  This was backwards.

Thanks to @Caspar007 for pointing it out.

Closes #98