### PR TITLE
Use same verbosity for Write-Log as main script

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -11,6 +11,11 @@ Function Write-Log {
 
     Begin { }
     Process {
+        # Inherit the same verbosity settings as the script importing this
+        if (-not $PSBoundParameters.ContainsKey('InformationPreference')) { $InformationPreference = $PSCmdlet.GetVariableValue('InformationPreference') }
+        if (-not $PSBoundParameters.ContainsKey('Verbose')) { $VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference') }
+        if (-not $PSBoundParameters.ContainsKey('Debug')) { $DebugPreference = $PSCmdlet.GetVariableValue('DebugPreference') }
+
         # Get mutex named MPMWriteLog. Mutexes are shared across all threads and processes.
         # This lets us ensure only one thread is trying to write to the file at a time.
         $mutex = New-Object System.Threading.Mutex($false, "MPMWriteLog")


### PR DESCRIPTION
Because it's in a separate module, Write-Log doesn't inherit the
verbose, debug and info preferences of the main script.  This sets them
to be the same as the main script.

Makes debugging easier when running MultiPoolMiner.ps1 with -debug
and/or -verbose.  No noticable change for anyone running the script
normally.