### PR TITLE
Fix typo in excavator API

### DIFF
--- a/APIs/Excavator.ps1
+++ b/APIs/Excavator.ps1
@@ -27,7 +27,7 @@ class Excavator : Miner {
         $this.BeginTime = Get-Date
 
         if ($this.Workers) {
-            if ([Excavator]::Service.Id = $this.Service_Id) {
+            if ([Excavator]::Service.Id -eq $this.Service_Id) {
                 $Request = @{id = 1; method = "workers.free"; params = $this.Workers} | ConvertTo-Json -Compress
 
                 try {


### PR DESCRIPTION
I'm not sure I entirely understand how the service id works for the excavator API, but I believe this was the intent of the code.

Fixes #1576 