### PR TITLE
Fix reporting failed miners as active

### DIFF
--- a/ReportStatus.ps1
+++ b/ReportStatus.ps1
@@ -8,11 +8,11 @@ param(
 )
 
 Write-Log "Pinging monitoring server. "
-$profit = ($ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.Status -eq "Running"} | Measure-Object Profit -Sum).Sum | ConvertTo-Json
+$profit = ($ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.GetStatus() -eq "Running"} | Measure-Object Profit -Sum).Sum | ConvertTo-Json
 
 # Format the miner values for reporting.  Set relative path so the server doesn't store anything personal (like your system username, if running from somewhere in your profile)
 $minerreport = ConvertTo-Json @(
-    $ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.Status -eq "Running"} | Foreach-Object {
+    $ActiveMiners | Where-Object {$_.Activated -GT 0 -and $_.GetStatus() -eq "Running"} | Foreach-Object {
         # Create a custom object to convert to json. Type, Pool, CurrentSpeed and EstimatedSpeed are all forced to be arrays, since they sometimes have multiple values.
         [pscustomobject]@{
             Name           = $_.Name


### PR DESCRIPTION
The Status property of the miners doesn't actually get set to failed anymore - needed to update it to use the GetStatus() function.

Fixes #1526