### PR TITLE
Remove URI from PheonixMiner

### DIFF
--- a/Miners/PhoenixMinerAmd.txt
+++ b/Miners/PhoenixMinerAmd.txt
@@ -8,7 +8,7 @@
                       },
         "API":  "Claymore",
         "Port":  "23335",
-        "URI":  "https://bitcointalk.org/index.php?topic=2647654.0"
+        "ManualURI":  "https://bitcointalk.org/index.php?topic=2647654.0"
     },
     {
         "Type":  "AMD",
@@ -19,6 +19,6 @@
                       },
         "API":  "Claymore",
         "Port":  "23335",
-        "URI":  "https://bitcointalk.org/index.php?topic=2647654.0"
+        "ManualURI":  "https://bitcointalk.org/index.php?topic=2647654.0"
     }
 ]

--- a/Miners/PhoenixMinerNvidia.txt
+++ b/Miners/PhoenixMinerNvidia.txt
@@ -8,7 +8,7 @@
                       },
         "API":  "Claymore",
         "Port":  "23334",
-        "URI":  "https://bitcointalk.org/index.php?topic=2647654.0"
+        "ManualURI":  "https://bitcointalk.org/index.php?topic=2647654.0"
     },
     {
         "Type":  "NVIDIA",
@@ -19,6 +19,6 @@
                       },
         "API":  "Claymore",
         "Port":  "23334",
-        "URI":  "https://bitcointalk.org/index.php?topic=2647654.0"
+        "ManualURI":  "https://bitcointalk.org/index.php?topic=2647654.0"
     }
 ]


### PR DESCRIPTION
Moved the URL to a new ManualURI property.

Having a bitcointalk URI property causes errors for the automatic downloader.
I want to keep the reference where to download it in the file, but not interfere with the automatic downloading.

In the future I intend to add manualURI to other miners that can't be automatically downloaded, and a way to display the ManualURI fields of any miners that are missing, so people can go download them themselves easily.