### PR TITLE
BMiner: Encode username & password

### DIFF
--- a/Miners/BMiner.txt
+++ b/Miners/BMiner.txt
@@ -1,7 +1,7 @@
 ﻿{
     "Type":  "NVIDIA",
     "Path":  ".\\Bin\\NVIDIA-BMiner\\BMiner.exe",
-    "Arguments":  "\"-api 127.0.0.1:1880 -uri $(if ($Pools.Equihash.SSL) {'stratum+ssl'}else {'stratum'})://$($Pools.Equihash.User):$($Pools.Equihash.Pass)@$($Pools.Equihash.Host):$($Pools.Equihash.Port) -nofee -watchdog=false\"",
+    "Arguments":  "\"-api 127.0.0.1:1880 -uri $(if ($Pools.Equihash.SSL) {'stratum+ssl'}else {'stratum'})://$(System.Web.HttpUtility]::UrlEncode($Pools.Equihash.User)):$(System.Web.HttpUtility]::UrlEncode($Pools.Equihash.Pass))@$($Pools.Equihash.Host):$($Pools.Equihash.Port) -nofee -watchdog=false\"",
     "HashRates":  {
                       "Equihash":  "\"$($Stats.Bminer_Equihash_HashRate.Week)\""
                   },


### PR DESCRIPTION
https://www.bminer.me/examples/#escaping-characters-in-the-uri

Some pools, e.g. zpool allow to define additional mining settings in the password field. See an example below:

BMiner.exe -api 127.0.0.1:1880 -uri stratum://1GSq8txFsg1je6yL8t6S94mYdF8cGqVQJF:BLACKBOX,c=BTC@equihash.mine.zpool.ca:2142 -devices 0

Bminer throws an error:

invalid value "stratum://1GSq8txFsg1je6yL8t6S94mYdF8cGqVQJF:BLACKBOX,c=BTC@equihash.mine.zpool.ca:2142" for flag -uri: Invalid port in the URI
Bminer: When Crypto-mining Made Fast (v7.0.0-9c7291b)

https://bitcointalk.org/index.php?topic=2519271.msg36173883#msg36173883