### PR TITLE
Include-psm1: Add function Get-Devices, Get-DeviceIDs & ConvertTo-CommandPerDeviceSet

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -2,7 +2,162 @@
 
 Add-Type -Path .\OpenCL\*.cs
 
-Function Write-Log {
+function Get-Devices {
+    [CmdletBinding()]
+
+    # returns a list of all OpenGL devices found.
+
+    $Devices = [PSCustomObject]@{}
+
+    [OpenCl.Platform]::GetPlatformIDs() | ForEach-Object { # Hardware platform
+        [OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All) | ForEach-Object {
+
+            if ($_.Type -eq "Cpu") {
+                $Type = "CPU"
+            }
+            else {
+                Switch ($_.Vendor) {
+                    "Advanced Micro Devices, Inc." {$Type = "AMD"}
+                    "Intel(R) Corporation"         {$Type = "INTEL"}
+                    "NVIDIA Corporation"           {$Type = "NVIDIA"}
+                }
+            }
+
+            if (-not $Devices.$Type) {
+                $Devices | Add-Member $Type @()
+                $DeviceID = 0 # For each platform start counting DeviceIDs from 0
+            }
+
+            $Name_Norm = (Get-Culture).TextInfo.ToTitleCase(($_.Name)) -replace "[^A-Z0-9]"
+
+            if ($Devices.$Type.Name_Norm -inotcontains $Name_Norm) { # New card model
+                $Device = $_
+                $Device | Add-Member Name_Norm $Name_Norm
+                $Device | Add-Member DeviceIDs @()
+                $Devices.$Type += $Device
+            }
+            $Devices.$Type | Where-Object {$_.Name_Norm -eq $Name_Norm} | ForEach-Object {$_.DeviceIDs += $DeviceID++} # Add DeviceID
+        }
+    }
+    $Devices
+}
+
+function Get-DeviceIDs {
+    # Filters the DeviceIDs and returns only DeviceIDs for active miners
+    # $DeviceIdBase: Returened  DeviceID numbers are of base $DeviceIdBase, e.g. HEX (16)
+    # $DeviceIdOffset: Change default numbering start from 0 -> $DeviceIdOffset
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject]$Config,
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject]$Devices,
+        [Parameter(Mandatory = $true)]
+        [String]$Type,
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject]$DeviceTypeModel,
+        [Parameter(Mandatory = $true)]
+        [Int]$DeviceIdBase,
+        [Parameter(Mandatory = $true)]
+        [Int]$DeviceIdOffset
+    )
+
+    $DeviceIDs  = [PSCustomObject]@{}
+    $DeviceIDs | Add-Member "All" @() # array of all devices, ids will be in hex format
+    $DeviceIDs | Add-Member "3gb" @() # array of all devices with more than 3MiB VRAM, ids will be in hex format
+    $DeviceIDs | Add-Member "4gb" @() # array of all devices with more than 4MiB VRAM, ids will be in hex format
+
+    # Get DeviceIDs, filter out all disabled hw models and IDs
+    if ($Config.MinerInstancePerCardModel) { # separate miner instance per hardware model
+        if ($Config.Devices.$Type.IgnoreHWModel -inotcontains $DeviceTypeModel.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $DeviceTypeModel.Name_Norm) {
+            $DeviceTypeModel.DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | ForEach-Object {
+                $DeviceIDs."All" += [Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)
+                if ($DeviceTypeModel.GlobalMemsize -ge 3000000000) {$DeviceIDs."3gb" += [Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+                if ($DeviceTypeModel.GlobalMemsize -ge 4000000000) {$DeviceIDs."4gb" += [Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+            }
+        }
+    }
+    else { # one miner instance per hw type
+        $DeviceIDs."All" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | ForEach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+        $DeviceIDs."3gb" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm} | Where-Object {$_.GlobalMemsize -gt 3000000000}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | Foreach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+        $DeviceIDs."4gb" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm} | Where-Object {$_.GlobalMemsize -gt 4000000000}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | Foreach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+    }
+    $DeviceIDs
+}
+
+function ConvertTo-CommandPerDeviceSet {
+
+    # converts the command parameters
+    # if a parameter has multiple values, only the values for the valid devices are returned
+    # parameters without values are valid for all devices and are left untouched
+
+    # supported parameter syntax:
+    #$Command = ",c=BTC -9 1  -y  2 -a 00,11,22,33,44,55  -b=00,11,22,33,44,55 --c==00,11,22,33,44,55 --d --e=00,11,22,33,44,55 -f -g 00 11 22 33 44 55 ,c=LTC  -h 00 11 22 33 44 55 -i=,11,,33,,55 --j=00,11,,,44,55 --k==00,,,33,44,55 -l -zzz=0123,1234,2345,3456,4567,5678,6789 -u 0  --p all ,something=withcomma blah *blah *blah"
+    #$DeviceIDs = @(0;1;4)
+    # Result: ",c=BTC -9 1  -y  2 -a 00,11,44  -b=00,11,44 --c==00,11,44 --d --e=00,11,44 -f -g 00 11 44 ,c=LTC  -h 00 11 44 -i=,11 --j=00,11,44 --k==00,,44 -l -zzz=0123,1234,4567 -u 0  --p all ,something=withcomma blah *blah *blah"
+    #$DeviceIDs = @(1)
+    # Result: ",c=BTC -9 1  -y  2 -a 11  -b=11 --c==11 --d --e=11 -f -g 11 ,c=LTC  -h 11 -i=11 --j=11 --k== -l -zzz=1234 -u 0  --p all ,something=withcomma blah *blah *blah"
+    #$DeviceIDs = @(0;2;9)
+    # Result: ",c=BTC -9 1  -y  2 -a 00,22  -b=00,22 --c==00,22 --d --e=00,22 -f -g 00 22 ,c=LTC  -h 00 22 -i= --j=00 --k==00 -l -zzz=0123,2345 -u 0  --p all ,something=withcomma blah *blah *blah"
+    # $Command = ",c=BTC -a 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16"
+    # $DeviceIDs = @("0";"A";"B"); $DeviceIdBase = 16
+    # Result: ",c=BTC -a 0,10,11"
+    # $DeviceIDs = @("1";"A";"B"); $DeviceIdBase = 16; $DeviceIdOffset = 1
+    # Result: ",c=BTC -a 0,9,10"
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [String]$Command,
+        [Parameter(Mandatory = $true)]
+        [Array]$DeviceIDs,
+        [Parameter(Mandatory = $true)]
+        [Int]$DeviceIdBase,
+        [Parameter(Mandatory = $false)]
+        [Int]$DeviceIdOffset
+    )
+
+    $CommandPerDeviceSet = ""
+
+    $Command -split "(?=\s{1,}--|\s{1,}-| ,|^,)" | ForEach-Object {
+        $Token = $_
+        $Prefix = $null
+        $ParameterValueSeparator = $null
+        $ValueSeparator = $null
+        $Values = $null
+
+        if ($Token.TrimStart() -match "(?:^[-=]{1,})") { # supported prefix characters are listed in brackets: [-=]{1,}
+
+            $Prefix = "$($Token -split $Matches[0] | Select-Object -Index 0)$($Matches[0])"
+            $Token = $Token -split $Matches[0] | Select-Object -Last 1
+
+            if ($Token -match "(?:[ =]{1,})") { # supported separators are listed in brackets: [ =]{1,}
+                $ParameterValueSeparator = $Matches[0]
+                $Parameter = $Token -split $ParameterValueSeparator | Select-Object -Index 0
+                $Values = $Token.Substring(("$($Parameter)$($ParameterValueSeparator)").length)
+
+                if ($Values -match "(?:[,; ]{1})") { # supported separators are listed in brackets: [,; ]{1}
+                    $ValueSeparator = $Matches[0]
+                    $RelevantValues = @()
+                    $DeviceIDs | Foreach-Object {
+                        $DeviceID = [Convert]::ToInt32($_, $DeviceIdBase) - $DeviceIdOffset
+                        if ($Values.Split($ValueSeparator) | Select-Object -Index $DeviceId) {$RelevantValues += ($Values.Split($ValueSeparator) | Select-Object -Index $DeviceId)}
+                        else {$RelevantValues += ""}
+                    }                    
+                    $CommandPerDeviceSet += "$($Prefix)$($Parameter)$($ParameterValueSeparator)$(($RelevantValues -join $ValueSeparator).TrimEnd($ValueSeparator))"
+                }
+                else {$CommandPerDeviceSet += "$($Prefix)$($Parameter)$($ParameterValueSeparator)$($Values)"}
+            }
+            else {$CommandPerDeviceSet += "$($Prefix)$($Token)"}
+        }
+        else {$CommandPerDeviceSet += $Token}
+    }
+    $CommandPerDeviceSet
+}
+
+function Write-Log {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][ValidateNotNullOrEmpty()][Alias("LogContent")][string]$Message,

--- a/Include.psm1
+++ b/Include.psm1
@@ -10,7 +10,7 @@ function Get-Devices {
     $Devices = [PSCustomObject]@{}
 
     [OpenCl.Platform]::GetPlatformIDs() | ForEach-Object { # Hardware platform
-        [OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All) | ForEach-Object {
+        [OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All) | ForEach-Object { # Device
 
             if ($_.Type -eq "Cpu") {
                 $Type = "CPU"

--- a/Include.psm1
+++ b/Include.psm1
@@ -63,7 +63,7 @@ function Get-DeviceIDs {
         [Int]$DeviceIdOffset
     )
 
-    $DeviceIDs  = [PSCustomObject]@{}
+    $DeviceIDs = [PSCustomObject]@{}
     $DeviceIDs | Add-Member "All" @() # array of all devices, ids will be in hex format
     $DeviceIDs | Add-Member "3gb" @() # array of all devices with more than 3MiB VRAM, ids will be in hex format
     $DeviceIDs | Add-Member "4gb" @() # array of all devices with more than 4MiB VRAM, ids will be in hex format


### PR DESCRIPTION
## Get-Devices

### Usage
The following should be added to MultiPoolMiner.ps1:
`$Devices = Get-Devices`

### Parameters
none

### What does it do?
Get-Devices returns a list of all OpenGL devices found.
It returns a data structure similar to this (converted to JSON for better readabiliy) which can be used for miner JSON generation:
```
{
    "CPU":  [
                {
                    "AddressBits":  64,
                    "Available":  true,
                    "CompilerAvailable":  true,
                    "DoubleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma",
                    "EndianLittle":  true,
                    "ErrorCorrectionSupport":  false,
                    "ExecCapabilities":  "ExecKernel, ExecNativeKernel",
                    "Extensions":  "cl_khr_fp64 cl_amd_fp64 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_gl_sharing cl_ext_device_fission cl_amd_device_attribute_query cl_amd_vec3 cl_amd_printf cl_amd_media_ops cl_amd_media_ops2 cl_amd_popcnt cl_khr_d3d10_sharing cl_khr_spir cl_khr_gl_event ",
                    "GlobalMemCacheSize":  32768,
                    "GlobalMemCacheType":  2,
                    "GlobalMemCachelineSize":  64,
                    "GlobalMemSize":  17110327296,
                    "ImageSupport":  true,
                    "LocalMemSize":  32768,
                    "LocalMemType":  2,
                    "MaxClockFrequency":  3398,
                    "MaxComputeUnits":  4,
                    "MaxConstantArgs":  8,
                    "MaxConstantBufferSize":  null,
                    "MaxMemAllocSize":  4277581824,
                    "MaxParameterSize":  4096,
                    "MaxReadImageArgs":  128,
                    "MaxSamplers":  16,
                    "MaxWorkGroupSize":  1024,
                    "MaxWorkItemDimensions":  3,
                    "MaxWorkItemSizes":  "1024 1024 1024",
                    "MaxWriteImageArgs":  64,
                    "MemBaseAddrAlign":  1024,
                    "MinDataTypeAlignSize":  128,
                    "Name":  "Intel(R) Core(TM) i5-4670K CPU @ 3.40GHz",
                    "ClVersion":  "OpenCL C 1.2 ",
                    "Platform":  "OpenCl.Platform",
                    "PreferredVectorWidthChar":  16,
                    "PreferredVectorWidthShort":  8,
                    "PreferredVectorWidthInt":  4,
                    "PreferredVectorWidthLong":  2,
                    "PreferredVectorWidthFloat":  8,
                    "PreferredVectorWidthDouble":  4,
                    "Profile":  "FULL_PROFILE",
                    "QueueProperties":  "ProfilingEnable",
                    "SingleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma, FpCorrectlyRoundedDivideSqrt",
                    "Type":  "Cpu",
                    "Vendor":  "GenuineIntel",
                    "VendorId":  4098,
                    "Version":  "OpenCL 1.2 AMD-APP (1912.5)",
                    "DriverVersion":  "1912.5 (sse2,avx)",
                    "Name_Norm":  "IntelRCoreTMI54670KCPU340Ghz",
                    "DeviceIDs":  "0"
                }
            ],
    "NVIDIA":  [
                   {
                       "AddressBits":  64,
                       "Available":  true,
                       "CompilerAvailable":  true,
                       "DoubleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma",
                       "EndianLittle":  true,
                       "ErrorCorrectionSupport":  false,
                       "ExecCapabilities":  "ExecKernel",
                       "Extensions":  "cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_fp64 cl_khr_byte_addressable_store cl_khr_icd cl_khr_gl_sharing cl_nv_compiler_options cl_nv_device_attribute_query cl_nv_pragma_unroll cl_nv_d3d10_sharing cl_khr_d3d10_sharing cl_nv_d3d11_sharing cl_nv_copy_opts cl_nv_create_buffer",
                       "GlobalMemCacheSize":  458752,
                       "GlobalMemCacheType":  2,
                       "GlobalMemCachelineSize":  128,
                       "GlobalMemSize":  11811160064,
                       "ImageSupport":  true,
                       "LocalMemSize":  49152,
                       "LocalMemType":  1,
                       "MaxClockFrequency":  1721,
                       "MaxComputeUnits":  28,
                       "MaxConstantArgs":  9,
                       "MaxConstantBufferSize":  null,
                       "MaxMemAllocSize":  2952790016,
                       "MaxParameterSize":  4352,
                       "MaxReadImageArgs":  256,
                       "MaxSamplers":  32,
                       "MaxWorkGroupSize":  1024,
                       "MaxWorkItemDimensions":  3,
                       "MaxWorkItemSizes":  "1024 1024 64",
                       "MaxWriteImageArgs":  16,
                       "MemBaseAddrAlign":  4096,
                       "MinDataTypeAlignSize":  128,
                       "Name":  "GeForce GTX 1080 Ti",
                       "ClVersion":  "OpenCL C 1.2 ",
                       "Platform":  "OpenCl.Platform",
                       "PreferredVectorWidthChar":  1,
                       "PreferredVectorWidthShort":  1,
                       "PreferredVectorWidthInt":  1,
                       "PreferredVectorWidthLong":  1,
                       "PreferredVectorWidthFloat":  1,
                       "PreferredVectorWidthDouble":  1,
                       "Profile":  "FULL_PROFILE",
                       "QueueProperties":  "OutOfOrderExecModeEnable, ProfilingEnable",
                       "SingleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma, FpCorrectlyRoundedDivideSqrt",
                       "Type":  "Gpu",
                       "Vendor":  "NVIDIA Corporation",
                       "VendorId":  4318,
                       "Version":  "OpenCL 1.2 CUDA",
                       "DriverVersion":  "390.65",
                       "Name_Norm":  "GeforceGTX1080Ti",
                       "DeviceIDs":  "0 4"
                   },
                   {
                       "AddressBits":  64,
                       "Available":  true,
                       "CompilerAvailable":  true,
                       "DoubleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma",
                       "EndianLittle":  true,
                       "ErrorCorrectionSupport":  false,
                       "ExecCapabilities":  "ExecKernel",
                       "Extensions":  "cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_fp64 cl_khr_byte_addressable_store cl_khr_icd cl_khr_gl_sharing cl_nv_compiler_options cl_nv_device_attribute_query cl_nv_pragma_unroll cl_nv_d3d10_sharing cl_khr_d3d10_sharing cl_nv_d3d11_sharing cl_nv_copy_opts cl_nv_create_buffer",
                       "GlobalMemCacheSize":  245760,
                       "GlobalMemCacheType":  2,
                       "GlobalMemCachelineSize":  128,
                       "GlobalMemSize":  8589934592,
                       "ImageSupport":  true,
                       "LocalMemSize":  49152,
                       "LocalMemType":  1,
                       "MaxClockFrequency":  1683,
                       "MaxComputeUnits":  15,
                       "MaxConstantArgs":  9,
                       "MaxConstantBufferSize":  null,
                       "MaxMemAllocSize":  2147483648,
                       "MaxParameterSize":  4352,
                       "MaxReadImageArgs":  256,
                       "MaxSamplers":  32,
                       "MaxWorkGroupSize":  1024,
                       "MaxWorkItemDimensions":  3,
                       "MaxWorkItemSizes":  "1024 1024 64",
                       "MaxWriteImageArgs":  16,
                       "MemBaseAddrAlign":  4096,
                       "MinDataTypeAlignSize":  128,
                       "Name":  "GeForce GTX 1070",
                       "ClVersion":  "OpenCL C 1.2 ",
                       "Platform":  "OpenCl.Platform",
                       "PreferredVectorWidthChar":  1,
                       "PreferredVectorWidthShort":  1,
                       "PreferredVectorWidthInt":  1,
                       "PreferredVectorWidthLong":  1,
                       "PreferredVectorWidthFloat":  1,
                       "PreferredVectorWidthDouble":  1,
                       "Profile":  "FULL_PROFILE",
                       "QueueProperties":  "OutOfOrderExecModeEnable, ProfilingEnable",
                       "SingleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma, FpCorrectlyRoundedDivideSqrt",
                       "Type":  "Gpu",
                       "Vendor":  "NVIDIA Corporation",
                       "VendorId":  4318,
                       "Version":  "OpenCL 1.2 CUDA",
                       "DriverVersion":  "390.65",
                       "Name_Norm":  "GeforceGTX1070",
                       "DeviceIDs":  "1 5"
                   },
                   {
                       "AddressBits":  64,
                       "Available":  true,
                       "CompilerAvailable":  true,
                       "DoubleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma",
                       "EndianLittle":  true,
                       "ErrorCorrectionSupport":  false,
                       "ExecCapabilities":  "ExecKernel",
                       "Extensions":  "cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_fp64 cl_khr_byte_addressable_store cl_khr_icd cl_khr_gl_sharing cl_nv_compiler_options cl_nv_device_attribute_query cl_nv_pragma_unroll cl_nv_d3d10_sharing cl_khr_d3d10_sharing cl_nv_d3d11_sharing cl_nv_copy_opts cl_nv_create_buffer",
                       "GlobalMemCacheSize":  147456,
                       "GlobalMemCacheType":  2,
                       "GlobalMemCachelineSize":  128,
                       "GlobalMemSize":  3221225472,
                       "ImageSupport":  true,
                       "LocalMemSize":  49152,
                       "LocalMemType":  1,
                       "MaxClockFrequency":  1771,
                       "MaxComputeUnits":  9,
                       "MaxConstantArgs":  9,
                       "MaxConstantBufferSize":  null,
                       "MaxMemAllocSize":  805306368,
                       "MaxParameterSize":  4352,
                       "MaxReadImageArgs":  256,
                       "MaxSamplers":  32,
                       "MaxWorkGroupSize":  1024,
                       "MaxWorkItemDimensions":  3,
                       "MaxWorkItemSizes":  "1024 1024 64",
                       "MaxWriteImageArgs":  16,
                       "MemBaseAddrAlign":  4096,
                       "MinDataTypeAlignSize":  128,
                       "Name":  "GeForce GTX 1060 3GB",
                       "ClVersion":  "OpenCL C 1.2 ",
                       "Platform":  "OpenCl.Platform",
                       "PreferredVectorWidthChar":  1,
                       "PreferredVectorWidthShort":  1,
                       "PreferredVectorWidthInt":  1,
                       "PreferredVectorWidthLong":  1,
                       "PreferredVectorWidthFloat":  1,
                       "PreferredVectorWidthDouble":  1,
                       "Profile":  "FULL_PROFILE",
                       "QueueProperties":  "OutOfOrderExecModeEnable, ProfilingEnable",
                       "SingleFpConfig":  "FpDenorm, FpInfNan, FpRoundToNearest, FpRoundToZero, FpRoundToInf, FpFma, FpCorrectlyRoundedDivideSqrt",
                       "Type":  "Gpu",
                       "Vendor":  "NVIDIA Corporation",
                       "VendorId":  4318,
                       "Version":  "OpenCL 1.2 CUDA",
                       "DriverVersion":  "390.65",
                       "Name_Norm":  "GeforceGTX10603GB",
                       "DeviceIDs":  "2 6"
                   }
               ]
}
```
### What is that good for?
If $Devices is passed as parameter (`Get-ChildItemContent "Miners" -Parameters @{Pools = $Pools; Stats = $Stats; Config = $Config; Devices = $Devices}`) it can then be used to construct miners more effectively, e.g.
`[OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where-Object {$_.Type -eq 'GPU' -and $_.Vendor -eq 'NVIDIA Corporation'} |`
can then be replaced with
`$Devices.NVIDIA | `
This saves a lot of unnecessary loops.

Furthermore $Devices.$Type contains an array of DeviceIDs per found card model. This can be used to enable miners for some card models only (e.g. cards with more than 2GB vram for Ethash).

See also https://github.com/MultiPoolMiner/MultiPoolMiner/pull/1122

## Get-DeviceIDs (used in miner files)

### What does it do?
Get-DeviceIDs returns the DeviceIDs of valid devices.
The function handles 3 things:

### 1) Numbering scheme (by parameter)
Miners use different numbering schemes for DeviceID selection.
Some miners use decimal values starting from 0 to nn, 
others start counting from 1,
and then there are some that expect the DeviceId to be in hex format.
The returned DeviceIDs will match the required numbering schemes

### 2) DeviceID filtering (by $Config)
All devices matching any of:
- $Config.Devices.$Type.IgnoreHWModel
- $Config.Devices.$Type.IgnoreDeviceID 
- $Config.Miners.$Name.IgnoreHWModel
- $Config.Miners.$Name.IgnoreDeviceID

will be excluded from the returned DeviceID lists.

### 3) DeviceID filtering (by memory size)
Some algorithms have a minimum VRAM memory limit. Get-DeviceSet generates 3 sets of DeviceIDs based on memory size (see _Return Value_ below)
### Usage
```
    # Get list of active devices, returned DeviceIDs are in hex format starting from 0
    $DeviceIDs = (Get-DeviceIDs -Config $Config -Devices $Devices -Base 16 -Offset 0)
```
### Parameters

The function does not need any extra parameters.
All required variables are inherited from the caller:

$Config:
Contains all configuration settings

$Devices:
Contains device information about all installed mining devices (result from Get-Devices)

$DeviceTypeModel:
Contains device information about the selected card model

$DeviceIdBase:
Defines the numbering format. It can be any int number:
- 10 will return decimal values
- 16 will return hex values

$DeviceIdOffset:
Can be used to define an positive offset: 
- default is 0
- for miners that start counting devices at 1 set to 1 

### Return value
Get-DeviceIDs returns a dataset with 3 elements. Each element contains an array of DeviceIDs:
        $DeviceSet."All":   Array of DeviceIDs irrespective of available VRAM
        $DeviceSet."3gb": Array of DeviceIDs with at least 3GB available VRAM
        $DeviceSet."4gb": Array of DeviceIDs with at least 4GB available VRAM

## ConvertTo-CommandPerDeviceSet (used in miner files)

### Usage
```
$Commands = ConvertTo-CommandPerDeviceSet -Command "command string to convert, e.g. ' -i 20,18,20,18 --submit-stale'" -DeviceIDs $DeviceIDs -DeviceIdBase $DeviceIdBase -DeviceIdOffset $DeviceIdOffset
```
### Parameters
```
        [Parameter(Mandatory = $true)]
        [AllowEmptyString()]
        [String]$Command,
        [Parameter(Mandatory = $true)]
        [Array]$DeviceIDs,
        [Parameter(Mandatory = $true)]
        [Int]$DeviceIdBase,
        [Parameter(Mandatory = $false)]
        [Int]$DeviceIdOffset
```
$Command:
Command string to be converted as it would apply if all devices were active (no device filtering applied, see Get-DeviceIDs)

$DeviceIDs:
Array containing all active device IDs, values are of base $DeviceIdBase

$DeviceIdBase:
Defines the numbering format of the numbers in $DeviceIDs. It should match the values used when calling Get-DeviceIDs.
- 10 for decimal values
- 16 for hex values

$DeviceIdOffset:
Defines offset of the numbers in $DeviceIDs. It should match the values used when calling Get-DeviceIDs.
- default is 0
- for miners that start counting devices at 1 set to 1

### What does it do?
It converts the command parameter.
If a parameter has multiple values (one per device), only the values for the available devices are returned. Parameters with non device-specific values are valid for all devices and are left untouched.

### What is it good for?
In the future (in development) MPM will be able to run separate miner instances per GPU deviceto further enhance profitability. The command line passed to each individual miner instance must be converted to only use the parameter values which apply for the current device.
Assume the following configuration:
- DeviceIDs 0 & 2: GTX1080
- DeviceIDs 1 & 3: GTX1070
- optional miner command line parameters for all devices: ' -i 20,18,20,18 --submit-stale'

If MPM runs two miner instances:
a) one for GTX1080 with deviceIDs 0 & 2
b) and another one for GTX1070 with deviceIDs 1 & 3)
the miner command line needs to be converted like this:
a) ' -i 20,20 --submit-stale'
b) ' -i 18,18 --submit-stale'

### Supported command parameter syntax
```
$Command = ",c=BTC -9 1  -y  2 -a 00,11,22,33,44,55  -b=00,11,22,33,44,55 --c==00,11,22,33,44,55 --d --e=00,11,22,33,44,55 -f -g 00 11 22 33 44 55 ,c=LTC  -h 00 11 22 33 44 55 -i=,11,,33,,55 --j=00,11,,,44,55 --k==00,,,33,44,55 -l -zzz=0123,1234,2345,3456,4567,5678,6789 -u 0  --p all ,something=withcomma blah *blah *blah"
$Devices = @(0;1;4)
Returns: ",c=BTC -9 1  -y  2 -a 00,11,44  -b=00,11,44 --c==00,11,44 --d --e=00,11,44 -f -g 00 11 44 ,c=LTC  -h 00 11 44 -i=,11 --j=00,11,44 --k==00,,44 -l -zzz=0123,1234,4567 -u 0  --p all ,something=withcomma blah *blah *blah"
$Devices = @(1)
Returns: ",c=BTC -9 1  -y  2 -a 11  -b=11 --c==11 --d --e=11 -f -g 11 ,c=LTC  -h 11 -i=11 --j=11 --k== -l -zzz=1234 -u 0  --p all ,something=withcomma blah *blah *blah"
$Devices = @(0;2;9)
Returns: ",c=BTC -9 1  -y  2 -a 00,22  -b=00,22 --c==00,22 --d --e=00,22 -f -g 00 22 ,c=LTC  -h 00 22 -i= --j=00 --k==00 -l -zzz=0123,2345 -u 0  --p all ,something=withcomma blah *blah *blah"
```
