### PR TITLE
Clear pool cache if the pool configuration has changed

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -210,8 +210,8 @@ while ($true) {
     #Give API access to the current running configuration
     $API.Config = $Config
 
-    #Clear pool cache if the configuration has changed
-    if (($ConfigBackup | ConvertTo-Json -Compress) -ne ($Config | ConvertTo-Json -Compress)) {$AllPools = $null}
+    #Clear pool cache if the pool configuration has changed
+    if (($ConfigBackup.Pools | ConvertTo-Json -Compress) -ne ($Config.Pools | ConvertTo-Json -Compress)) {$AllPools = $null}
 
     if ($Config.Proxy) {$PSDefaultParameterValues["*:Proxy"] = $Config.Proxy}
     else {$PSDefaultParameterValues.Remove("*:Proxy")}


### PR DESCRIPTION
More and more settings are being moved to $Config.
Not every $Config change should trigger the $pool variable to get cleared.