### PR TITLE
Remove tribus

### DIFF
--- a/Miners/CcminerKlaust.ps1
+++ b/Miners/CcminerKlaust.ps1
@@ -20,7 +20,6 @@ $Commands = [PSCustomObject]@{
     "penta" = "" #Pentablake
     "skein" = "" #Skein
     "s3" = "" #S3
-    "tribus" = "" #Tribus
     "veltor" = "" #Veltor
     #"whirlpool" = "" #Whirlpool
     #"whirlpoolx" = "" #whirlpoolx


### PR DESCRIPTION
`ccminer.exe -a tribus -b 4068 -o stratum+tcp://tribus.mine.blazepool.com:8533 -u 1GPSq8txFnyrYdXL8t6S94mYdF8cGqVQJF -p ID=BlackBox,c=BTC`
ccminer 8.21-KlausT (64bit) for nVidia GPUs
Compiled with Visual Studio 2015 using Nvidia CUDA Toolkit 9.1

Based on pooler cpuminer 2.3.2 and the tpruvot@github fork
CUDA support by Christian Buchner, Christian H. and DJM34
Includes optimizations implemented by sp-hash, klaust, tpruvot and tsiv.

[2018-05-09 14:44:45] **Error: no algo or invalid algo**