### PR TITLE
CcminerSP remove yesscrypt

### DIFF
--- a/Miners/CcminerSp.ps1
+++ b/Miners/CcminerSp.ps1
@@ -30,7 +30,6 @@ $Commands = [PSCustomObject]@{
     #"whirlpool" = "" #Whirlpool
     #"whirlpoolx" = "" #whirlpoolx
     "x17" = "" #x17
-    "yescrypt" = "" #Yescrypt
 
     # ASIC - never profitable 27/03/2018
     #"blake" = "" #blake


### PR DESCRIPTION
Miner bombs out on yescrypt. Can someone confirm please.

ccminer.exe -a yescrypt -o stratum+tcp://yescrypt.us.hashrefinery.com:6233 -u 1GPSq8txFnyrYdXL8t6S94mYdF8cGqVQJF -p BlackBox,c=BTC -b 4068
SP-Mod 1.5.81
Compiled with Visual C++ 18 using Nvidia CUDA Toolkit 7.5

  Based on pooler cpuminer 2.3.2 and the tpruvot@github fork
  CUDA support by Christian Buchner, Christian H. and DJM34
  Includes optimizations implemented by sp, klaust, tpruvot and tsiv.

Try `ccminer --help' for more information.