### PR TITLE
Add $ShowMinerWindow

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -62,7 +62,9 @@ param(
     [Parameter(Mandatory = $false)]
     [Double]$SwitchingPrevention = 1, #zero does not prevent miners switching
     [Parameter(Mandatory = $false)]
-    [Switch]$DisableAutoUpdate = $false
+    [Switch]$DisableAutoUpdate = $false,
+    [Parameter(Mandatory = $false)]
+    [Switch]$ShowMinerWindow = $false #if true all miner windows will be visible (they can steal focus)
 )
 
 $Version = "2.7.2.7"
@@ -113,7 +115,6 @@ $WalletDonate = @("1Q24z7gHPDbedkaWDTFqhMF8g7iHMehsCb", "1Fonyo1sgJQjEzqp1AxgbHh
 $UserNameDonate = @("aaronsace", "fonyo")[[Math]::Floor((Get-Random -Minimum 1 -Maximum 11) / 10)]
 $WorkerNameDonate = "multipoolminer"
 
-
 #Initialize the API
 Import-Module .\API.psm1
 Start-APIServer
@@ -150,6 +151,7 @@ while ($true) {
             MinerStatusURL           = $MinerStatusURL
             MinerStatusKey           = $MinerStatusKey
             SwitchingPrevention      = $SwitchingPrevention
+            ShowMinerWindow          = $ShowMinerWindow
         } | Select-Object -ExpandProperty Content
     }
     else {
@@ -176,6 +178,7 @@ while ($true) {
             MinerStatusURL           = $MinerStatusURL
             MinerStatusKey           = $MinerStatusKey
             SwitchingPrevention      = $SwitchingPrevention
+            ShowMinerWindow          = $ShowMinerWindow
         }
     }
 
@@ -506,6 +509,7 @@ while ($true) {
                 New                  = $false
                 Benchmarked          = 0
                 Pool                 = $Miner.Pools.PSObject.Properties.Value.Name
+                ShowMinerWindow      = $Config.ShowMinerWindow
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Since version 2.6, the delta value (integer) that was used to determine how ofte
 **-disableautoupdate**
 By default MPM will perform an automatic update on startup if a newer version is found. Set to 'true' to disable automatic update to latest MPM version. 
 
+**-ShowMinerWindow
+By default MPM hides most miner windows as to not steal focus. All miners write their output to files in the Log folder. Set to 'true' to show miner windows (old MPM behaviour).
+
 
 ##SAMPLE USAGE
 #####(check "start.bat" file in root folder)
@@ -307,6 +310,24 @@ E.g. to change the payout currency for Zpool to LiteCoin replace the line for BT
         "Worker": "$WorkerName"
     }
     
+
+### Advanced general configuration
+
+Settings in this section affect the overall behaviour of MPM.
+
+#### To show miner windows
+
+By default MPM hides most miner windows as to not steal focus. All miners write their output to files in the Log folder.
+
+To show the miner windows add '"ShowMinerWindow":  true' to the general section in Config.txt:
+Note: Showing the miner windows disables writing the miner output to log files.
+
+{
+    ...
+    "SwitchingPrevention":  "$SwitchingPrevention",
+    "ShowMinerWindow":  true,
+    ...
+}
 
 
 ## MULTIPOOLMINER'S LOGIC

--- a/README.txt
+++ b/README.txt
@@ -75,7 +75,7 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -region [Europe/US/Asia]
 	Choose your region or the region closest to you.
 
--poolname [ahashpool, ahashpoolcoins, blazepool, blockmasters, blockmasterscoins, hashrefinery, miningpoolhub, miningpoolhubcoins, nicehash, yiimp, zergpool, ZergPoolCoins, zpool]
+-poolname [ahashpool, ahashpoolcoins, blazepool, blockmasters, blockmasterscoins, hashrefinery, miningpoolhub, miningpoolhubcoins, nicehash, yiimp, zergpool, zergpoolcoins, zpool]
 	The following pools are currently supported (in alphabetical order): 
 
     ## AHashPool / AHashPoolCoins
@@ -203,6 +203,9 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -disableautoupdate
 	By default MPM will perform an automatic update on startup if a newer version is found. Set to 'true' to disable automatic update to latest MPM version. 
 
+-ShowMinerWindow
+	By default MPM hides most miner windows as to not steal focus. All miners write their output to files in the Log folder. Set to 'true' to show miner windows (old MPM behaviour).
+
 	
 ====================================================================
 
@@ -319,6 +322,24 @@ E.g. to change the payout currency for Zpool to LiteCoin replace the line for BT
         "Worker": "$WorkerName"
     }
 
+
+Advanced general configuration
+
+Settings in this section affect the overall behaviour of MPM.
+
+To show miner windows
+
+By default MPM hides most miner windows as to not steal focus. All miners write their output to files in the Log folder.
+Note: Showing the miner windows disables writing the miner output to log files.
+
+To show the miner windows add '"ShowMinerWindow":  true' to the general section in Config.txt:
+
+{
+    ...
+    "SwitchingPrevention":  "$SwitchingPrevention",
+    "ShowMinerWindow":  true,
+    ...
+}
 
 ====================================================================
 
@@ -509,5 +530,3 @@ PID: process ID of the miner application being used
 BTC/day: Estimated Bitcoin earnings per day
 
 The monitoring service can change, evolve, be unavailable any time without prior notice. The contents of the database will NOT be shared with any third-parties but we reserve the right to create metrics out of it and use its contents to improve or promote our services and MultiPoolMiner. Credits to @grantemsley for the codebase.
-
-


### PR DESCRIPTION
Start command parameter 
**-ShowMinerWindow $true**
will show miner windows (old MPM behaviour).

Alternatively you can modify Config.txt:

```
...
    "SwitchingPrevention":  "$SwitchingPrevention",
    "ShowMinerWindow":  true
}
```

Default is $false, so windows will remain hidden and write their output to the log files.