### PR TITLE
Fixes for powershell updating

### DIFF
--- a/Updater.ps1
+++ b/Updater.ps1
@@ -27,7 +27,12 @@ catch {
 $Name = "PowerShell"
 try {
     $ProgressPreference = "SilentlyContinue"
-    $Request = Invoke-RestMethod -Uri "https://api.github.com/repos/powershell/$Name/releases/latest" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+    $Request = Invoke-RestMethod -Uri "https://api.github.com/repos/powershell/$Name/releases" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+
+    # Filter to only show the latest non-preview release
+    $LatestVersion = $Request.tag_name | Where-Object {$_ -notmatch '-preview' -and $_ -notmatch '-rc' -and $_ -notmatch '-beta' -and $_ -notmatch '-alpha'} | Select-Object -First 1
+    $Request = $Request | Where-Object {$_.tag_name -eq $LatestVersion}
+
     $Version = ($Request.tag_name -replace '^v')
     $URI = $Request.assets | Where-Object Name -EQ "$($Name)-$($Version)-win-x64.msi" | Select-Object -ExpandProperty browser_download_url
 

--- a/Updater.ps1
+++ b/Updater.ps1
@@ -6,6 +6,14 @@ if ($script:MyInvocation.MyCommand.Path) {Set-Location (Split-Path $script:MyInv
 
 $ProgressPreferenceBackup = $ProgressPreference
 
+
+Function Get-Version ($Version) {
+    # System.Version objects can be compared with -gt and -lt properly
+    # This strips out anything that doens't belong in a version, eg. v at the beginning, or -preview1 at the end, and returns a version object
+    Return [System.Version]($Version -Split "-" -Replace "[^0-9.]")[0]
+}
+
+
 $Name = "MultiPoolMiner"
 try {
     $ProgressPreference = "SilentlyContinue"
@@ -13,12 +21,14 @@ try {
     $Version = ($Request.tag_name -replace '^v')
     $Uri = $Request.assets | Where-Object Name -EQ "$($Name)V$($Version).zip" | Select-Object -ExpandProperty browser_download_url
 
-    if ($Version -ne $MPMVersion) {
-        $ProgressPreference = $ProgressPreferenceBackup
-        Write-Progress -Activity "Updater" -Status $Name -CurrentOperation "Acquiring Online ($URI)"
-        $ProgressPreference = "SilentlyContinue"
-        Write-Log -Level Warn "The software ($Name) is out of date; there is an updated version available at $URI. "
+    if ( (Get-Version($Version)) -gt (Get-Version($MPMVersion)) ) {
+        Write-Log -Level Warn "$Name is out of date; current version $(Get-Version($Version)), lastest release $(Get-Version($Version)) - there is an updated version available at $URI. "
     }
+
+    if ( (Get-Version($Version)) -lt (Get-Version($MPMVersion)) ) {
+        Write-Log -Level Warn "You are running prerelease version $(Get-Version($Version)) of $Name. Use at your own risk."
+    }
+
 }
 catch {
     Write-Log -Level Warn "The software ($Name) failed to update. "
@@ -36,7 +46,7 @@ try {
     $Version = ($Request.tag_name -replace '^v')
     $URI = $Request.assets | Where-Object Name -EQ "$($Name)-$($Version)-win-x64.msi" | Select-Object -ExpandProperty browser_download_url
 
-    if ($Version -ne $PSVersion) {
+    if ( (Get-Version($Version)) -gt (Get-Version($PSVersion)) ) {
         $ProgressPreference = $ProgressPreferenceBackup
         Write-Progress -Activity "Updater" -Status $Name -CurrentOperation "Acquiring Online ($URI)"
         $ProgressPreference = "SilentlyContinue"


### PR DESCRIPTION
This makes 2 changes to the updating:

- Filters out preview releases from powershell's release list. Instead it will find the latest one not marked with -preview, -rc, -beta or -alpha.  Unfortunately, they don't take their preview releases properly: https://github.com/PowerShell/PowerShell/issues/6830
- Uses [System.Version] objects to compare the current and latest version numbers instead of just making sure they are equal.  For MultiPoolMiner, it will give a different warning if the running version is newer or older than the latest release.  For Powershell, it will only try to update if the latest release is newer, so if you are running a preview version, it won't try to "update" you to an older release

Closes #1600 
