### PR TITLE
Fix CPU mining when OpenCL drivers not installed

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -167,7 +167,8 @@ while ($true) {
     }
 
     #Only use configured types that are present in system
-    $Config.Type = $Config.Type | Where-Object {$Devices.$_}
+    #Explicitly include CPU, because it won't show up as a device if OpenGL drivers for CPU are not installed
+    $Config.Type = $Config.Type | Where-Object {$Devices.$_ -or $_ -eq 'CPU'}
 
     #Error in Config.txt
     if ($Config -isnot [PSCustomObject]) {


### PR DESCRIPTION
Include CPU type even if it isn't listed in $Devices

Closes #1666.