### PR TITLE
Fix Palgin download link

### DIFF
--- a/Miners/PalginNvidia.txt
+++ b/Miners/PalginNvidia.txt
@@ -8,5 +8,5 @@
                   },
     "API":  "Wrapper",
     "Port":  "23333",
-    "URI":  "https://github.com/palginpav/hsrminer/blob/master/HSR%20algo/Windows/hsrminer_hsr.zip"
+    "URI":  "https://github.com/MultiPoolMiner/miner-binaries/releases/download/hsrpalgin1.0/hsrminer_hsr.zip"
 }


### PR DESCRIPTION
They didn't create a release, just uploaded the exe in their repo.

This makes a webpage (where github would normally show you a diff) get downloaded instead of the actual zip file.