### PR TITLE
Show benchmarking progress

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -685,6 +685,13 @@ while ($true) {
 
         $MinerComparisons | Out-Host
     }
+
+    #Display benchmarking progress
+    $BenchmarksNeeded = ($miners | Where {$_.HashRates.PSObject.Properties.Value -eq $null}).Count
+    if($BenchmarksNeeded -gt 0) {
+        Write-Log -Level Warn "Benchmarking in progress: $($BenchmarksNeeded) miners left to benchmark."
+    }
+
     #Give API access to WatchdogTimers information
     $API.WatchdogTimers = $WatchdogTimers
 


### PR DESCRIPTION
With all miners and algorithms enabled, it's hard to see how many more
are left to benchmark.  This shows a line at the end with how many
miners are still being benchmarked.

Once all the miners have been benchmarked the warning goes away.