### PR TITLE
10x speed increase loading miners

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -600,8 +600,9 @@ function Get-Algorithm {
         [Parameter(Mandatory = $false)]
         [String]$Algorithm = ""
     )
+
     if(-not (Test-Path Variable:Script:Algorithms)) {
-        $Algorithms = Get-Content "Algorithms.txt" | ConvertFrom-Json
+        $Script:Algorithms = Get-Content "Algorithms.txt" | ConvertFrom-Json
     }
 
     $Algorithm = (Get-Culture).TextInfo.ToTitleCase(($Algorithm -replace "-", " " -replace "_", " ")) -replace " "
@@ -617,11 +618,13 @@ function Get-Region {
         [String]$Region = ""
     )
 
-    $Regions = Get-Content "Regions.txt" | ConvertFrom-Json
-
+    if(-not (Test-Path Variable:Script:Regions)) {
+        $Script:Regions = Get-Content "Regions.txt" | ConvertFrom-Json
+    }
+    
     $Region = (Get-Culture).TextInfo.ToTitleCase(($Region -replace "-", " " -replace "_", " ")) -replace " "
 
-    if ($Regions.$Region) {$Regions.$Region}
+    if ($Script:Regions.$Region) {$Script:Regions.$Region}
     else {$Region}
 }
 

--- a/Include.psm1
+++ b/Include.psm1
@@ -600,12 +600,13 @@ function Get-Algorithm {
         [Parameter(Mandatory = $false)]
         [String]$Algorithm = ""
     )
-
-    $Algorithms = Get-Content "Algorithms.txt" | ConvertFrom-Json
+    if(-not (Test-Path Variable:Script:Algorithms)) {
+        $Algorithms = Get-Content "Algorithms.txt" | ConvertFrom-Json
+    }
 
     $Algorithm = (Get-Culture).TextInfo.ToTitleCase(($Algorithm -replace "-", " " -replace "_", " ")) -replace " "
 
-    if ($Algorithms.$Algorithm) {$Algorithms.$Algorithm}
+    if ($Script:Algorithms.$Algorithm) {$Script:Algorithms.$Algorithm}
     else {$Algorithm}
 }
 


### PR DESCRIPTION
I've been profiling the code and seeing where it is slow.  With all miners and algorithms enabled, it takes one of my systems between 5 and 10 minutes to finish ONE loop.

This is the biggest performance increase for the smallest amount of work I've found so far:  Caching Algorithms.txt so it doesn't get read and converted from JSON every time it is called.  The first time Get-Algorithms is called, it will be converted from json and saved to a module local $Algorithms variable.  If it's called again, it checks if that variable is already set and uses the previous results.

## Performance testing

### System:  Windows 10, i7-6800k, SSD, AMD and NVIDIA cards

| Task | Before | After | Percent Increase |
|---|---|---|---|
|Loading pools|27859ms|17798ms|56.5%|
|Loading miners|35709ms|4130ms|764.6%|

### System: Server 2012R2, AMD A10-5800K, regular slow hard drive, NVIDIA card only
| Task | Before | After | Percent Increase|
|---|---|---|---|
|Loading pools|85668ms|40571ms|111.2%|
|Loading miners|133541ms|9615ms|**1288.9%**|
