### PR TITLE
Add InfoOnly flag to config

### DIFF
--- a/Get-Binaries.ps1
+++ b/Get-Binaries.ps1
@@ -12,11 +12,13 @@ Param(
     [Switch]$SkipAMD = $false,
     [Parameter(Mandatory = $false)]
     [Switch]$SkipNVIDIA = $false
-
 )
 
 # Make sure we are in the script's directory
 Set-Location (Split-Path $MyInvocation.MyCommand.Path)
+
+# Add info flag to $Config; required for proper miner enumeration
+$Config | Add-Member InfoOnly $true
 
 # Get device information
 $Devices = Get-Devices

--- a/Miners/ClaymoreNvidia.ps1
+++ b/Miners/ClaymoreNvidia.ps1
@@ -80,7 +80,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
         default     {$DeviceIDs = $DeviceIDsAll}
     }
 
-    if ($Pools.$MainAlgorithm_Norm -and $DeviceIDs) { # must have a valid pool to mine and available devices
+    if (($Pools.$MainAlgorithm_Norm -and $DeviceIDs) -or $Config.InfoOnly) { # must have a valid pool to mine and available devices
 
         $Miner_Name = $Name
         $MainAlgorithmCommands = $Commands.$_.Split(";") | Select -Index 0 # additional command line options for main algorithm


### PR DESCRIPTION
Add a temporary flag 'InfoOnly' to $Config. (type [Bool])

All new miners (e.g. ClaymoreDual) will need this flag to be present to compatible with Get-Binaries.

If the flag is present the miners will report all necessary information requested by Get-Binaries. Without it the will not return any information and the binary version can not be checked.