### PR TITLE
Load miners in parallel

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -80,8 +80,8 @@ function Get-DeviceIDs {
     }
     else { # one miner instance per hw type
         $DeviceIDs."All" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | ForEach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
-        $DeviceIDs."3gb" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm} | Where-Object {$_.GlobalMemsize -gt 3000000000}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | Foreach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
-        $DeviceIDs."4gb" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm} | Where-Object {$_.GlobalMemsize -gt 4000000000}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | Foreach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+        $DeviceIDs."3gb" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm} | Where-Object {$_.GlobalMemsize -gt 3000000000}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | ForEach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
+        $DeviceIDs."4gb" = @($Devices.$Type | Where-Object {$Config.Devices.$Type.IgnoreHWModel -inotcontains $_.Name_Norm -and $Config.Miners.$Name.IgnoreHWModel -inotcontains $_.Name_Norm} | Where-Object {$_.GlobalMemsize -gt 4000000000}).DeviceIDs | Where-Object {$Config.Devices.$Type.IgnoreDeviceID -notcontains $_ -and $Config.Miners.$Name.IgnoreDeviceID -notcontains $_} | ForEach-Object {[Convert]::ToString(($_ + $DeviceIdOffset), $DeviceIdBase)}
     }
     $DeviceIDs
 }
@@ -141,7 +141,7 @@ function ConvertTo-CommandPerDeviceSet {
                 if ($Values -match "(?:[,; ]{1})") { # supported separators are listed in brackets: [,; ]{1}
                     $ValueSeparator = $Matches[0]
                     $RelevantValues = @()
-                    $DeviceIDs | Foreach-Object {
+                    $DeviceIDs | ForEach-Object {
                         $DeviceID = [Convert]::ToInt32($_, $DeviceIdBase) - $DeviceIdOffset
                         if ($Values.Split($ValueSeparator) | Select-Object -Index $DeviceId) {$RelevantValues += ($Values.Split($ValueSeparator) | Select-Object -Index $DeviceId)}
                         else {$RelevantValues += ""}
@@ -428,8 +428,8 @@ function Get-ChildItemContentParallel {
     # Determine how many threads to use based on how many cores the system has, but force it to be between 2 and 8.
     $Threads = 2 # Default
     $Threads = ((Get-CimInstance win32_processor).NumberOfLogicalProcessors | Measure-Object -Sum).Sum 
-    if ($Threads -lt 2) { $Threads = 2 }
-    if ($Threads -gt 8) { $Threads = 8 }
+    if ($Threads -lt 2) {$Threads = 2}
+    if ($Threads -gt 8) {$Threads = 8}
 
     # Create a runspace pool with up to $Threads threads
     $RunspaceCollection = @()
@@ -487,8 +487,8 @@ function Get-ChildItemContentParallel {
     }
 
     # Get each requested file and process it in a runspace
-    Get-ChildItem $Path -File -ErrorAction SilentlyContinue | Foreach-Object {
-        $Powershell = [powershell]::Create().AddScript($ProcessItem,$true).AddArgument($ScriptDir).AddArgument($_).AddArgument($Parameters)
+    Get-ChildItem $Path -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $Powershell = [powershell]::Create().AddScript($ProcessItem, $true).AddArgument($ScriptDir).AddArgument($_).AddArgument($Parameters)
         $Powershell.RunspacePool = $RunSpacePool
 
         # Add to the collection of runspaces
@@ -499,8 +499,8 @@ function Get-ChildItemContentParallel {
     }
 
     # Wait for all runspaces to finish running and get their data
-    While($RunspaceCollection) {
-        Foreach($Runspace in $RunspaceCollection.ToArray()) {
+    While ($RunspaceCollection) {
+        ForEach($Runspace in $RunspaceCollection.ToArray()) {
             if ($Runspace.Runspace.IsCompleted) {
                 # End the runspace and get the returned objects
                 $Runspace.PowerShell.EndInvoke($Runspace.Runspace)

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -309,7 +309,7 @@ while ($true) {
     # select only the ones that have a HashRate matching our algorithms, and that only include algorithms we have pools for
     # select only the miners that match $Config.MinerName, if specified, and don't match $Config.ExcludeMinerName
     $AllMiners = if (Test-Path "Miners") {
-        Get-ChildItemContent "Miners" -Parameters @{Pools = $Pools; Stats = $Stats; Config = $Config; Devices = $Devices} | ForEach-Object {$_.Content | Add-Member Name $_.Name -PassThru -Force} | 
+        Get-ChildItemContentParallel "Miners" -Parameters @{Pools = $Pools; Stats = $Stats; Config = $Config; Devices = $Devices} | ForEach-Object {$_.Content | Add-Member Name $_.Name -PassThru -Force} | 
             Where-Object {$Config.Type.Count -eq 0 -or (Compare-Object $Config.Type $_.Type -IncludeEqual -ExcludeDifferent | Measure-Object).Count -gt 0} | 
             Where-Object {($Config.Algorithm.Count -eq 0 -or (Compare-Object $Config.Algorithm $_.HashRates.PSObject.Properties.Name | Where-Object SideIndicator -EQ "=>" | Measure-Object).Count -eq 0) -and ((Compare-Object $Pools.PSObject.Properties.Name $_.HashRates.PSObject.Properties.Name | Where-Object SideIndicator -EQ "=>" | Measure-Object).Count -eq 0)} | 
             Where-Object {$Config.ExcludeAlgorithm.Count -eq 0 -or (Compare-Object $Config.ExcludeAlgorithm $_.HashRates.PSObject.Properties.Name -IncludeEqual -ExcludeDifferent | Measure-Object).Count -eq 0} | 


### PR DESCRIPTION
This uses multiple threads to load miners. It automatically detects the number of cores in your system, and uses that many runspace threads to load them.  I tried a few variations of this idea, and this is the one that worked the best.

Testing on both fast and slow systems showed this almost halved the time to load the miner files (and this is after the speed boost from the recent get-algorithm changes!). 

The same can (and will, eventually) be applied to loading pool data, and I expect the benefits to be even greater there since one slow responding pool API makes the whole script wait.  But right now they are called one by one so I need to rewrite that section of code first in a separate PR.

Loading stats in parallel shows no improvement, and actually runs a bit slower, because it's a mostly disk bound operation.

@UselessGuru this could potentially break some of the things you are working on, especially if multiple miners write to the same file in your code (not sure if they do or not).  But if it does, it should still be pretty easy to work around.