### PR TITLE
Add $UseFastestMinerPerAlgoOnly parameter

### DIFF
--- a/API.psm1
+++ b/API.psm1
@@ -69,8 +69,16 @@
                     $Data = $API.AllPools | ConvertTo-Json
                     Break
                 }
+                "/algorithms" {
+                    $Data = ($API.AllPools.Algorithm | Sort-Object -Unique) | ConvertTo-Json
+                    Break
+                }
                 "/miners" {
                     $Data = $API.Miners | ConvertTo-Json
+                    Break
+                }
+                "/fastestminers" {
+                    $Data = $API.FastestMiners | ConvertTo-Json
                     Break
                 }
                 "/config" {

--- a/APIDocs.html
+++ b/APIDocs.html
@@ -22,6 +22,10 @@
     <a href="http://localhost:3999/activeminers">/activeminers</a>
     <p>Shows data about all miners that are enabled.</p>
     
+    <h3>Fastest Miners</h3>
+    <a href="http://localhost:3999/fastestminers">/fastestminers</a>
+    <p>Shows data about the fastest miners (requires 'UseFastestMinerPerAlgoOnly = $true', otherwise will be identical to 'Miners'; see readme).</p>
+    
     <h3>Failed Miners</h3>
     <a href="http://localhost:3999/failedminers">/failedminers</a>
     <p>Shows data about all miners that are failed.</p>
@@ -37,6 +41,10 @@
     <h3>AllPools</h3>
     <a href="http://localhost:3999/allpools">/allpools</a>
     <p>Dump of the $AllPools variable</p>
+    
+    <h3>Algorithms</h3>
+    <a href="http://localhost:3999/algorithms">/algorithms</a>
+    <p>Shows all algorithms that can be mined with at least one pool</p>
     
     <h3>Config</h3>
     <a href="http://localhost:3999/config">/config</a>

--- a/Config.default.txt
+++ b/Config.default.txt
@@ -40,5 +40,6 @@
   "Watchdog": "$Watchdog",
   "MinerStatusURL": "$MinerStatusURL",
   "MinerStatusKey": "$MinerStatusKey",
-  "SwitchingPrevention": "$SwitchingPrevention"
+  "SwitchingPrevention": "$SwitchingPrevention",
+  "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly"
 }

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -427,8 +427,14 @@ while ($true) {
         ($Miner_WatchdogTimers | Measure-Object | Select-Object -ExpandProperty Count) -lt <#stage#>2 -and ($Miner_WatchdogTimers | Where-Object {$Miner.HashRates.PSObject.Properties.Name -contains $_.Algorithm} | Measure-Object | Select-Object -ExpandProperty Count) -lt <#stage#>1
     }
 
+    #Give API access to the miners information
+    $API.Miners = $Miners
+
     #Use only use fastest miner per algo and device index. E.g. if there are 2 miners available to mine the same algo, only the faster of the two will ever be used, the slower ones will also be hidden in the summary screen
     if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.Name})"}, {($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.Name})"} | Foreach-Object {$_.Group[0]}}
+
+    #Give API access to the fasted miners information
+    $API.FastestMiners = $Miners
 
     #Update the active miners
     if ($Miners.Count -eq 0) {
@@ -437,8 +443,6 @@ while ($true) {
         Start-Sleep $Config.Interval
         continue
     }
-    #Give API access to the miners information
-    $API.Miners = $Miners
 
     $ActiveMiners | ForEach-Object {
         $_.Profit = 0

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -692,7 +692,7 @@ while ($true) {
     }
 
     #Display benchmarking progress
-    $BenchmarksNeeded = ($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -eq $null}).Count
+    $BenchmarksNeeded = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -eq $null}).Count
     if ($BenchmarksNeeded -gt 0) {
         Write-Log -Level Warn "Benchmarking in progress: $($BenchmarksNeeded) miners left to benchmark."
     }

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -428,7 +428,7 @@ while ($true) {
     }
 
     #Use only use fastest miner per algo and device index. E.g. if there are 2 miners available to mine the same algo, only the faster of the two will ever be used, the slower ones will also be hidden in the summary screen
-    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = ($Miners | Group-Object Index).Group | Sort-Object -Descending {$_.HashRates.PSObject.Properties.Name -join ""} ,{($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {$_.HashRates.PSObject.Properties.Name -join ""} | Foreach-Object {$_.Group[0]}}
+    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')"} ,{($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')"} | Foreach-Object {$_.Group[0]}}
 
     #Update the active miners
     if ($Miners.Count -eq 0) {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -428,7 +428,7 @@ while ($true) {
     }
 
     #Use only use fastest miner per algo and device index. E.g. if there are 2 miners available to mine the same algo, only the faster of the two will ever be used, the slower ones will also be hidden in the summary screen
-    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if(($_ | Where-Object Profit -EQ $null | Measure-Object).Count) {$_.HashSHA256})"}, {($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if(($_ | Where-Object Profit -EQ $null | Measure-Object).Count) {$_.HashSHA256})"} | Foreach-Object {$_.Group[0]}}
+    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.HashSHA256})"}, {($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.HashSHA256})"} | Foreach-Object {$_.Group[0]}}
 
     #Update the active miners
     if ($Miners.Count -eq 0) {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -428,7 +428,7 @@ while ($true) {
     }
 
     #Use only use fastest miner per algo and device index. E.g. if there are 2 miners available to mine the same algo, only the faster of the two will ever be used, the slower ones will also be hidden in the summary screen
-    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')"} ,{($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')"} | Foreach-Object {$_.Group[0]}}
+    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if(($_ | Where-Object Profit -EQ $null | Measure-Object).Count) {$_.HashSHA256})"}, {($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if(($_ | Where-Object Profit -EQ $null | Measure-Object).Count) {$_.HashSHA256})"} | Foreach-Object {$_.Group[0]}}
 
     #Update the active miners
     if ($Miners.Count -eq 0) {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -165,6 +165,7 @@ while ($true) {
             MinerStatusKey           = $MinerStatusKey
             SwitchingPrevention      = $SwitchingPrevention
             ShowMinerWindow          = $ShowMinerWindow
+            UseFastestMinerPerAlgoOnly = $UseFastestMinerPerAlgoOnly
         } | Select-Object -ExpandProperty Content
     }
 

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -428,7 +428,7 @@ while ($true) {
     }
 
     #Use only use fastest miner per algo and device index. E.g. if there are 2 miners available to mine the same algo, only the faster of the two will ever be used, the slower ones will also be hidden in the summary screen
-    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.HashSHA256})"}, {($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.HashSHA256})"} | Foreach-Object {$_.Group[0]}}
+    if ($Config.UseFastestMinerPerAlgoOnly) {$Miners = $Miners | Sort-Object -Descending {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.Name})"}, {($_ | Where-Object Profit -EQ $null | Measure-Object).Count}, {($_ | Measure-Object Profit_Bias -Sum).Sum}, {($_ | Where-Object Profit -NE 0 | Measure-Object).Count} | Group-Object {"$($_.Type -join '')$($_.Index -join '')$($_.HashRates.PSObject.Properties.Name -join '')$(if($_.HashRates.PSObject.Properties.Value -eq $null) {$_.Name})"} | Foreach-Object {$_.Group[0]}}
 
     #Update the active miners
     if ($Miners.Count -eq 0) {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -694,7 +694,7 @@ while ($true) {
     #Display benchmarking progress
     $BenchmarksNeeded = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -eq $null}).Count
     if ($BenchmarksNeeded -gt 0) {
-        Write-Log -Level Warn "Benchmarking in progress: $($BenchmarksNeeded) miners left to benchmark."
+        Write-Log -Level Warn "Benchmarking in progress: $($BenchmarksNeeded) miner$(if ($BenchmarksNeeded -gt 1){'s'}) left to benchmark."
     }
 
     #Give API access to WatchdogTimers information

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ###### Licensed under the GNU General Public License v3.0 - Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/LICENSE
 
-README.md is based on README.txt - updated on 09/05/2018 - v1.23.03 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
+README.md is based on README.txt - updated on 13/05/2018 - v1.23.05 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
 
 
 
@@ -195,6 +195,9 @@ By default MPM will perform an automatic update on startup if a newer version is
 
 **-ShowMinerWindow
 By default MPM hides most miner windows as to not steal focus. All miners write their output to files in the Log folder. Set to 'true' to show miner windows (old MPM behaviour).
+
+**-UseFastestMinerPerAlgoOnly**
+Use only use fastest miner per algo and device index. E.g. if there are 2 or more miners available to mine the same algo, only the fastest will ever be used, the slower ones will also be hidden in the summary screen.
 
 
 ##SAMPLE USAGE

--- a/README.txt
+++ b/README.txt
@@ -17,7 +17,7 @@ TWITTER: @multipoolminer
 Licensed under the GNU General Public License v3.0
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/LICENSE
 
-README.txt - updated on 09/05/2018 (dd/mm/yyyy) - v1.23.03 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
+README.txt - updated on 13/05/2018 (dd/mm/yyyy) - v1.23.05 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
 
 ====================================================================
 
@@ -206,7 +206,10 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -ShowMinerWindow
 	By default MPM hides most miner windows as to not steal focus. All miners write their output to files in the Log folder. Set to 'true' to show miner windows (old MPM behaviour).
 
-	
+-UseFastestMinerPerAlgoOnly
+	Use only use fastest miner per algo and device index. E.g. if there are 2 or more miners available to mine the same algo, only the fastest will ever be used, the slower ones will also be hidden in the summary screen.
+
+
 ====================================================================
 
 
@@ -343,6 +346,7 @@ To show the miner windows add '"ShowMinerWindow":  true' to the general section 
     "ShowMinerWindow":  true,
     ...
 }
+
 
 ====================================================================
 


### PR DESCRIPTION
This may speed up MPM a bit.

It also makes the miner overview more compact by showing only profitable miners.
This was already suggested here: https://github.com/MultiPoolMiner/MultiPoolMiner/issues/1197

It will still benchmark all miners - unbenchmarked miners will remain in the list until benchmarked.