### PR TITLE
Improve Stats Performance

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -348,6 +348,18 @@ function Set-Stat {
     $Stat
 }
 
+function Get-Stats {
+    $Stats = [PSCustomObject]@{}
+    if (-not (Test-Path "Stats")) {New-Item "Stats" -ItemType "directory" | Out-Null}
+    Get-ChildItem "Stats" | Foreach-Object {
+        $Name = $_.BaseName
+        $_ | Get-Content | ConvertFrom-Json | ForEach-Object {
+            $Stats | Add-Member $Name $_
+        }
+    }
+    Return $Stats
+}
+
 function Get-Stat {
     [CmdletBinding()]
     param(

--- a/Include.psm1
+++ b/Include.psm1
@@ -348,27 +348,29 @@ function Set-Stat {
     $Stat
 }
 
-function Get-Stats {
-    $Stats = [PSCustomObject]@{}
-    if (-not (Test-Path "Stats")) {New-Item "Stats" -ItemType "directory" | Out-Null}
-    Get-ChildItem "Stats" | Foreach-Object {
-        $Name = $_.BaseName
-        $_ | Get-Content | ConvertFrom-Json | ForEach-Object {
-            $Stats | Add-Member $Name $_
-        }
-    }
-    Return $Stats
-}
-
 function Get-Stat {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [String]$Name
     )
 
     if (-not (Test-Path "Stats")) {New-Item "Stats" -ItemType "directory" | Out-Null}
-    Get-ChildItem "Stats" -File | Where-Object Extension -NE ".ps1" | Where-Object BaseName -EQ $Name | Get-Content | ConvertFrom-Json
+
+    if ($Name) {
+        # Return single requested stat
+        Get-ChildItem "Stats" -File | Where-Object BaseName -EQ $Name | Get-Content | ConvertFrom-Json
+    } else {
+        # Return all stats
+        $Stats = [PSCustomObject]@{}
+        Get-ChildItem "Stats" | ForEach-Object {
+            $BaseName = $_.BaseName
+            $_ | Get-Content | ConvertFrom-Json | ForEach-Object {
+                $Stats | Add-Member $BaseName $_
+            }
+        }
+        Return $Stats
+    }
 }
 
 function Get-ChildItemContent {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -242,7 +242,7 @@ while ($true) {
 
     #Load the stats
     Write-Log "Loading saved statistics. "
-    $Stats = Get-Stats
+    $Stats = Get-Stat
     #Give API access to the current stats
     $API.Stats = $Stats
 
@@ -746,7 +746,7 @@ while ($true) {
         #Benchmark timeout
         if ($Miner.Benchmarked -ge ($Strikes * $Strikes) -or ($Miner.Benchmarked -ge $Strikes -and $Miner.GetActivateCount() -ge $Strikes)) {
             $Miner.Algorithm | Where-Object {-not $Miner_HashRate.$_} | ForEach-Object {
-                if ((Get-Stat "$($Miner.Name)_$($_)_HashRate") -eq $null) {
+                if ((Get-Stat -Name "$($Miner.Name)_$($_)_HashRate") -eq $null) {
                     $Stat = Set-Stat -Name "$($Miner.Name)_$($_)_HashRate" -Value 0 -Duration $StatSpan
                 }
             }

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -242,8 +242,7 @@ while ($true) {
 
     #Load the stats
     Write-Log "Loading saved statistics. "
-    $Stats = [PSCustomObject]@{}
-    if (Test-Path "Stats") {Get-ChildItemContent "Stats" | ForEach-Object {$Stats | Add-Member $_.Name $_.Content}}
+    $Stats = Get-Stats
     #Give API access to the current stats
     $API.Stats = $Stats
 


### PR DESCRIPTION
Stats used Get-ChildItemContent, but there are never any scripts or variable substitution used in the stats files.

Loading the files directly is roughly twice as fast, saving about 5 seconds on my system.