### PR TITLE
Important: Fix memory leak in runspaces

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -524,6 +524,11 @@ function Get-ChildItemContentParallel {
             }
         }
     }
+    # Cleanup runspaces
+    $RunspacePool.Close()
+    $RunspacePool.Dispose()
+    Remove-Variable RunspacePool
+    Remove-Variable RunspaceCollection
 }
 
 filter ConvertTo-Hash { 


### PR DESCRIPTION
Runspaces were not being disposed of properly, causing increased memory usage and leaving extra threads running.

This disposes of them properly.