### PR TITLE
Remove unsupported algo whirlpoolx

### DIFF
--- a/Miners/CcminerAlexis.ps1
+++ b/Miners/CcminerAlexis.ps1
@@ -20,7 +20,6 @@ $Commands = [PSCustomObject]@{
     "veltor"     = " -i 23" #Veltor; fix for default intensity
     "whirlcoin"  = "" #WhirlCoin
     "whirlpool"  = "" #Whirlpool
-    "whirlpoolx" = "" #whirlpoolx
     "x11evo"     = " -N 1 -i 21" #X11evo; fix for default intensity, N samples for hashrate
     "x17"        = " -i 20" #x17; fix for default intensity
 


### PR DESCRIPTION
ccminer.exe -a whirlpoolx -o stratum+tcp://whirlpoolx.eu.nicehash.com:3343 -u XXXX.YYY -p x
*** ccminer alexis-1.2 for nVidia GPUs from alexis78@github ***
*** ccminer alexis-1.2 compiled by nemosminer@github ***
*** Built with VC++ 2013 and nVidia CUDA SDK 7.5 (Recommended)

*** Based on tpruvot@github ccminer
*** Originally based on Christian Buchner and Christian H. project
*** Include some of the work of djm34, sp, tsiv and klausT.
                        Alexis78-v1.2

[2018-05-18 09:07:55] Unknown algo parameter 'whirlpoolx'