### PR TITLE
AllowNull() in Get-DeviceIDs

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -57,8 +57,8 @@ function Get-DeviceIDs {
         [Parameter(Mandatory = $true)]
         [String]$Type,
         [Parameter(Mandatory = $true)]
-        [PSCustomObject]$DeviceTypeModel,
         [AllowNull()]
+        [PSCustomObject]$DeviceTypeModel,
         [Parameter(Mandatory = $true)]
         [Int]$DeviceIdBase,
         [Parameter(Mandatory = $true)]

--- a/Include.psm1
+++ b/Include.psm1
@@ -58,6 +58,7 @@ function Get-DeviceIDs {
         [String]$Type,
         [Parameter(Mandatory = $true)]
         [PSCustomObject]$DeviceTypeModel,
+        [AllowNull()]
         [Parameter(Mandatory = $true)]
         [Int]$DeviceIdBase,
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
to prevent error messages when no hardware of $Type is installed