### PR TITLE
Update ClaymoreDual (AMD & NVIDIA)

### DIFF
--- a/Miners/ClaymoreAmd.ps1
+++ b/Miners/ClaymoreAmd.ps1
@@ -92,7 +92,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                     $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
                 }
                 #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentSingleMode, 0)
+                $Fees = @($MinerFeeInPercentSingleMode)
             }
             
             # Single mining mode

--- a/Miners/ClaymoreAmd.ps1
+++ b/Miners/ClaymoreAmd.ps1
@@ -86,13 +86,13 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             else {
                 if (($DeviceIDsSet."3gb").Count -eq 0) {
                     # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
-                    $MinerFeeInPercentDualMode = 0
+                    $MinerFeeInPercentSingleMode = 0
                 }
                 else {
-                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
                 }
                 #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentDualMode, 0)
+                $Fees = @($MinerFeeInPercentSingleMode, 0)
             }
             
             # Single mining mode

--- a/Miners/ClaymoreAmd.ps1
+++ b/Miners/ClaymoreAmd.ps1
@@ -8,11 +8,11 @@ param(
 )
 
 $Type = "AMD"
-if (-not $Devices.$Type) {return} # No AMD present in system
+if (-not $Devices.$Type -and -not $Config.InfoOnly) {return} # No AMD mining device present in system
 
 $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName)"
 $Path = ".\Bin\Ethash-Claymore\EthDcrMiner64.exe"
-$HashSHA256 = "11743a7b0f8627ceb088745f950557e303c7350f8e4241814c39904278204580"
+$HashSHA256 = "11743A7B0F8627CEB088745F950557E303C7350F8E4241814C39904278204580"
 $API = "Claymore"
 $URI = "https://github.com/MultiPoolMiner/miner-binaries/releases/download/ethdcrminer64/ClaymoreDual_v11.7.zip"
 $Port = 13333
@@ -24,9 +24,9 @@ $Commands = [PSCustomObject]@{
     "ethash;blake2s:40"     = @("", "")
     "ethash;blake2s:60"     = @("", "")
     "ethash;blake2s:80"     = @("", "")
+    "ethash;decred:40"      = @("", "")
+    "ethash;decred:70"      = @("", "")
     "ethash;decred:100"     = @("", "")
-    "ethash;decred:130"     = @("", "")
-    "ethash;decred:160"     = @("", "")
     "ethash;keccak:20"      = @("", "")
     "ethash;keccak:30"      = @("", "")
     "ethash;keccak:40"      = @("", "")
@@ -39,9 +39,9 @@ $Commands = [PSCustomObject]@{
     "ethash2gb;blake2s:40"  = @("", "")
     "ethash2gb;blake2s:60"  = @("", "")
     "ethash2gb;blake2s:80"  = @("", "")
+    "ethash2gb;decred:40"   = @("", "")
+    "ethash2gb;decred:70"   = @("", "")
     "ethash2gb;decred:100"  = @("", "")
-    "ethash2gb;decred:130"  = @("", "")
-    "ethash2gb;decred:160"  = @("", "")
     "ethash2gb;keccak:20"   = @("", "")
     "ethash2gb;keccak:30"   = @("", "")
     "ethash2gb;keccak:40"   = @("", "")
@@ -68,7 +68,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
         default     {$DeviceIDs = $DeviceIDsSet."All"}
     }
 
-    if ($Pools.$MainAlgorithm_Norm -and $DeviceIDs) { # must have a valid pool to mine and available devices
+    if (($Pools.$MainAlgorithm_Norm -and $DeviceIDs) -or $Config.InfoOnly) { # must have a valid pool to mine and available devices
 
         $Miner_Name = $Name
         $MainAlgorithmCommands = $Commands.$_ | Select -Index 0 # additional command line options for main algorithm
@@ -80,9 +80,21 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             $Miner_Name = "$($Miner_Name)$($MainAlgorithm_Norm -replace '^ethash', '')"
             $HashRateMainAlgorithm = ($Stats."$($Miner_Name)_$($MainAlgorithm_Norm)_HashRate".Week)
 
-            $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
-            $Fees = @($MinerFeeInPercentSingleMode)
-
+            if ($Config.IgnoreMinerFee -or $Config.Miners.$Name.IgnoreMinerFee) {
+                $Fees = @($null)
+            }
+            else {
+                if (($DeviceIDsSet."3gb").Count -eq 0) {
+                    # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
+                    $MinerFeeInPercentDualMode = 0
+                }
+                else {
+                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                }
+                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                $Fees = @($MinerFeeInPercentDualMode, 0)
+            }
+            
             # Single mining mode
             [PSCustomObject]@{
                 Name       = $Miner_Name
@@ -107,9 +119,20 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             $HashRateMainAlgorithm = ($Stats."$($Miner_Name)_$($MainAlgorithm_Norm)_HashRate".Week)
             $HashRateSecondaryAlgorithm = ($Stats."$($Miner_Name)_$($SecondaryAlgorithm_Norm)_HashRate".Week)
 
-            #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-            $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
-            $Fees = @($MinerFeeInPercentDualMode, 0)
+            if ($Config.IgnoreMinerFee -or $Config.Miners.$Name.IgnoreMinerFee) {
+                $Fees = @($null)
+            }
+            else {
+                if (($DeviceIDsSet."3gb").Count -eq 0) {
+                    # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
+                    $MinerFeeInPercentDualMode = 0
+                }
+                else {
+                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                }
+                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                $Fees = @($MinerFeeInPercentDualMode, 0)
+            }
 
             if ($Pools.$SecondaryAlgorithm_Norm -and $SecondaryAlgorithmIntensity -gt 0) { # must have a valid pool to mine and positive intensity
                 [PSCustomObject]@{
@@ -117,31 +140,12 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                     Type       = $Type
                     Path       = $Path
                     HashSHA256 = $HashSHA256
-                    Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
+                    Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 1 -y 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
                     HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm; "$SecondaryAlgorithm_Norm" = $HashRateSecondaryAlgorithm}
                     API        = $Api
                     Port       = $Port
                     URI        = $Uri
                     Fees       = $Fees
-                }
-            }
-            if ($SecondaryAlgorithm_Norm -eq "Sia" -or $SecondaryAlgorithm_Norm -eq "Decred") {
-                $SecondaryAlgorithm_Norm = "$($SecondaryAlgorithm_Norm)NiceHash"
-                $HashRateSecondaryAlgorithm = ($Stats."$($Miner_Name)_$($SecondaryAlgorithm_Norm)_HashRate".Week)
-
-                if ($Pools.$SecondaryAlgorithm_Norm -and $SecondaryAlgorithmIntensity -gt 0) { # must have a valid pool to mine and positive intensity
-                    [PSCustomObject]@{
-                        Name       = $Miner_Name
-                        Type       = $Type
-                        Path       = $Path
-                        HashSHA256 = $HashSHA256
-                        Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
-                        HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm; "$SecondaryAlgorithm_Norm" = $HashRateSecondaryAlgorithm}
-                        API        = $Api
-                        Port       = $Port
-                        URI        = $Uri
-                        Fees       = $Fees
-                    }
                 }
             }
         }

--- a/Miners/ClaymoreAmd.ps1
+++ b/Miners/ClaymoreAmd.ps1
@@ -86,13 +86,13 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             else {
                 if (($DeviceIDsSet."3gb").Count -eq 0) {
                     # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
-                    $MinerFeeInPercentSingleMode = 0
+                    $Fees = @($null) 
                 }
                 else {
                     $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
+                    #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                    $Fees = @($MinerFeeInPercentSingleMode)
                 }
-                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentSingleMode)
             }
             
             # Single mining mode
@@ -125,13 +125,13 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             else {
                 if (($DeviceIDsSet."3gb").Count -eq 0) {
                     # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
-                    $MinerFeeInPercentDualMode = 0
+                    $Fees = @($null)
                 }
                 else {
                     $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                    #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                    $Fees = @($MinerFeeInPercentDualMode, 0)
                 }
-                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentDualMode, 0)
             }
 
             if ($Pools.$SecondaryAlgorithm_Norm -and $SecondaryAlgorithmIntensity -gt 0) { # must have a valid pool to mine and positive intensity

--- a/Miners/ClaymoreAmd.ps1
+++ b/Miners/ClaymoreAmd.ps1
@@ -74,7 +74,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
         $MainAlgorithmCommands = $Commands.$_ | Select -Index 0 # additional command line options for main algorithm
         $SecondaryAlgorithmCommands = $Commands.$_ | Select -Index 1 # additional command line options for secondary algorithm
 
-        if ($Pools.$MainAlgorithm_Norm.Name -eq 'NiceHash') {$EthereumStratumMode = "3"} else {$EthereumStratumMode = "2"} #Optimize stratum compatibility
+        if ($Pools.$MainAlgorithm_Norm.Name -eq 'NiceHash') {$EthereumStratumMode = " -esm 3"} else {$EthereumStratumMode = " -esm 2"} #Optimize stratum compatibility
 
         if ($_ -notmatch ";") { # single algo mining
             $Miner_Name = "$($Miner_Name)$($MainAlgorithm_Norm -replace '^ethash', '')"
@@ -101,7 +101,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                 Type       = $Type
                 Path       = $Path
                 HashSHA256 = $HashSHA256
-                Arguments  = ("-mode 1 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm_Norm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins 1 -platform 1 -y 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
+                Arguments  = ("-mode 1 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm_Norm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0)$EthereumStratumMode -allpools 1 -allcoins 1 -platform 1 -y 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
                 HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm}
                 API        = $Api
                 Port       = $Port
@@ -140,7 +140,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                     Type       = $Type
                     Path       = $Path
                     HashSHA256 = $HashSHA256
-                    Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 1 -y 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
+                    Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0)$EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 1 -y 1 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
                     HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm; "$SecondaryAlgorithm_Norm" = $HashRateSecondaryAlgorithm}
                     API        = $Api
                     Port       = $Port

--- a/Miners/ClaymoreNvidia.ps1
+++ b/Miners/ClaymoreNvidia.ps1
@@ -86,13 +86,13 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             else {
                 if (($DeviceIDsSet."3gb").Count -eq 0) {
                     # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
-                    $MinerFeeInPercentSingleMode = 0
+                    $Fees = @($null)
                 }
                 else {
                     $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
+                    #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                    $Fees = @($MinerFeeInPercentSingleMode)
                 }
-                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentSingleMode)
             }
 
             # Single mining mode
@@ -123,14 +123,15 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                 $Fees = @($null)
             }
             else {
-                if (($DeviceIDsSet."3gb").Count -eq 0) { # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
-                    $MinerFeeInPercentDualMode = 0
+                if (($DeviceIDsSet."3gb").Count -eq 0) {
+                    # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
+                    $Fees = @($null)
                 }
                 else {
                     $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                    #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                    $Fees = @($MinerFeeInPercentDualMode, 0)
                 }
-                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentDualMode, 0)
             }
 
             if ($Pools.$SecondaryAlgorithm_Norm -and $SecondaryAlgorithmIntensity -gt 0) { # must have a valid pool to mine and positive intensity

--- a/Miners/ClaymoreNvidia.ps1
+++ b/Miners/ClaymoreNvidia.ps1
@@ -86,13 +86,13 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             else {
                 if (($DeviceIDsSet."3gb").Count -eq 0) {
                     # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
-                    $MinerFeeInPercentDualMode = 0
+                    $MinerFeeInPercentSingleMode = 0
                 }
                 else {
-                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
                 }
                 #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentDualMode, 0)
+                $Fees = @($MinerFeeInPercentSingleMode, 0)
             }
 
             # Single mining mode

--- a/Miners/ClaymoreNvidia.ps1
+++ b/Miners/ClaymoreNvidia.ps1
@@ -74,7 +74,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
         $MainAlgorithmCommands = $Commands.$_ | Select -Index 0 # additional command line options for main algorithm
         $SecondaryAlgorithmCommands = $Commands.$_ | Select -Index 1 # additional command line options for secondary algorithm
 
-        if ($Pools.$MainAlgorithm_Norm.Name -eq 'NiceHash') {$EthereumStratumMode = "3"} else {$EthereumStratumMode = "2"} #Optimize stratum compatibility
+        if ($Pools.$MainAlgorithm_Norm.Name -eq 'NiceHash') {$EthereumStratumMode = " -esm 3"} else {$EthereumStratumMode = " -esm 2"} #Optimize stratum compatibility
 
         if ($_ -notmatch ";") { # single algo mining
             $Miner_Name = "$($Miner_Name)$($MainAlgorithm_Norm -replace '^ethash', '')"
@@ -101,7 +101,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                 Type       = $Type
                 Path       = $Path
                 HashSHA256 = $HashSHA256
-                Arguments  = ("-mode 1 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm_Norm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins 1 -platform 2 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
+                Arguments  = ("-mode 1 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm_Norm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$EthereumStratumMode$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -allpools 1 -allcoins 1 -platform 2 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
                 HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm}
                 API        = $Api
                 Port       = $Port
@@ -139,7 +139,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                     Type       = $Type
                     Path       = $Path
                     HashSHA256 = $HashSHA256
-                    Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 2 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
+                    Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$EthereumStratumMode$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 2 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
                     HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm; "$SecondaryAlgorithm_Norm" = $HashRateSecondaryAlgorithm}
                     API        = $Api
                     Port       = $Port

--- a/Miners/ClaymoreNvidia.ps1
+++ b/Miners/ClaymoreNvidia.ps1
@@ -92,7 +92,7 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                     $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
                 }
                 #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-                $Fees = @($MinerFeeInPercentSingleMode, 0)
+                $Fees = @($MinerFeeInPercentSingleMode)
             }
 
             # Single mining mode

--- a/Miners/ClaymoreNvidia.ps1
+++ b/Miners/ClaymoreNvidia.ps1
@@ -8,7 +8,7 @@ param(
 )
 
 $Type = "NVIDIA"
-if (-not $Devices.$Type) {return} # No NVIDIA mining device present in system
+if (-not $Devices.$Type -and -not $Config.InfoOnly) {return} # No NVIDIA mining device present in system
 
 $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName)"
 $Path = ".\Bin\Ethash-Claymore\EthDcrMiner64.exe"
@@ -24,9 +24,9 @@ $Commands = [PSCustomObject]@{
     "ethash;blake2s:40"     = @("", "")
     "ethash;blake2s:60"     = @("", "")
     "ethash;blake2s:80"     = @("", "")
+    "ethash;decred:40"      = @("", "")
+    "ethash;decred:70"      = @("", "")
     "ethash;decred:100"     = @("", "")
-    "ethash;decred:130"     = @("", "")
-    "ethash;decred:160"     = @("", "")
     "ethash;keccak:20"      = @("", "")
     "ethash;keccak:30"      = @("", "")
     "ethash;keccak:40"      = @("", "")
@@ -39,9 +39,9 @@ $Commands = [PSCustomObject]@{
     "ethash2gb;blake2s:40"  = @("", "")
     "ethash2gb;blake2s:60"  = @("", "")
     "ethash2gb;blake2s:80"  = @("", "")
+    "ethash2gb;decred:40"   = @("", "")
+    "ethash2gb;decred:70"   = @("", "")
     "ethash2gb;decred:100"  = @("", "")
-    "ethash2gb;decred:130"  = @("", "")
-    "ethash2gb;decred:160"  = @("", "")
     "ethash2gb;keccak:20"   = @("", "")
     "ethash2gb;keccak:30"   = @("", "")
     "ethash2gb;keccak:40"   = @("", "")
@@ -80,8 +80,20 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             $Miner_Name = "$($Miner_Name)$($MainAlgorithm_Norm -replace '^ethash', '')"
             $HashRateMainAlgorithm = ($Stats."$($Miner_Name)_$($MainAlgorithm_Norm)_HashRate".Week)
 
-            $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentSingleMode / 100)
-            $Fees = @($MinerFeeInPercentSingleMode)
+            if ($Config.IgnoreMinerFee -or $Config.Miners.$Name.IgnoreMinerFee) {
+                $Fees = @($null)
+            }
+            else {
+                if (($DeviceIDsSet."3gb").Count -eq 0) {
+                    # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
+                    $MinerFeeInPercentDualMode = 0
+                }
+                else {
+                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                }
+                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                $Fees = @($MinerFeeInPercentDualMode, 0)
+            }
 
             # Single mining mode
             [PSCustomObject]@{
@@ -107,9 +119,19 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
             $HashRateMainAlgorithm = ($Stats."$($Miner_Name)_$($MainAlgorithm_Norm)_HashRate".Week)
             $HashRateSecondaryAlgorithm = ($Stats."$($Miner_Name)_$($SecondaryAlgorithm_Norm)_HashRate".Week)
 
-            #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
-            $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
-            $Fees = @($MinerFeeInPercentDualMode, 0)
+            if ($Config.IgnoreMinerFee -or $Config.Miners.$Name.IgnoreMinerFee) {
+                $Fees = @($null)
+            }
+            else {
+                if (($DeviceIDsSet."3gb").Count -eq 0) { # All GPUs are 2GB, miner is completely free in this case, developer fee will not be mined at all.
+                    $MinerFeeInPercentDualMode = 0
+                }
+                else {
+                    $HashRateMainAlgorithm = $HashRateMainAlgorithm * (1 - $MinerFeeInPercentDualMode / 100)
+                }
+                #Second coin (Decred/Siacoin/Lbry/Pascal/Blake2s/Keccak) is mined without developer fee
+                $Fees = @($MinerFeeInPercentDualMode, 0)
+            }
 
             if ($Pools.$SecondaryAlgorithm_Norm -and $SecondaryAlgorithmIntensity -gt 0) { # must have a valid pool to mine and positive intensity
                 [PSCustomObject]@{
@@ -123,25 +145,6 @@ $Commands | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Select-Obj
                     Port       = $Port
                     URI        = $Uri
                     Fees       = $Fees
-                }
-            }
-            if ($SecondaryAlgorithm_Norm -eq "Sia" -or $SecondaryAlgorithm_Norm -eq "Decred") {
-                $SecondaryAlgorithm_Norm = "$($SecondaryAlgorithm_Norm)NiceHash"
-                $HashRateSecondaryAlgorithm = ($Stats."$($Miner_Name)_$($SecondaryAlgorithm_Norm)_HashRate".Week)
-
-                if ($Pools.$SecondaryAlgorithm_Norm -and $SecondaryAlgorithmIntensity -gt 0) { # must have a valid pool to mine and positive intensity
-                    [PSCustomObject]@{
-                        Name       = $Miner_Name
-                        Type       = $Type
-                        Path       = $Path
-                        HashSHA256 = $HashSHA256
-                        Arguments  = ("-mode 0 -mport -$Port -epool $($Pools.$MainAlgorithm_Norm.Host):$($Pools.$MainAlgorithm.Port) -ewal $($Pools.$MainAlgorithm_Norm.User) -epsw $($Pools.$MainAlgorithm_Norm.Pass)$MainAlgorithmCommands$($CommonCommands | Select -Index 0) -esm $EthereumStratumMode -allpools 1 -allcoins exp -dcoin $SecondaryAlgorithm -dcri $SecondaryAlgorithmIntensity -dpool $($Pools.$SecondaryAlgorithm_Norm.Host):$($Pools.$SecondaryAlgorithm_Norm.Port) -dwal $($Pools.$SecondaryAlgorithm_Norm.User) -dpsw $($Pools.$SecondaryAlgorithm_Norm.Pass)$SecondaryAlgorithmCommands$($CommonCommands | Select -Index 1) -platform 2 -di $($DeviceIDs -join '')" -replace "\s+", " ").trim()
-                        HashRates  = [PSCustomObject]@{"$MainAlgorithm_Norm" = $HashRateMainAlgorithm; "$SecondaryAlgorithm_Norm" = $HashRateSecondaryAlgorithm}
-                        API        = $Api
-                        Port       = $Port
-                        URI        = $Uri
-                        Fees       = $Fees
-                    }
                 }
             }
         }


### PR DESCRIPTION
- added ignore miner fee switch support
- reduced decred intensities (far too high if used together with OhGodAnETHlargementPill)
- added $Config.InfoOnly support (required for Get-Binaries)
- removed Sia / SiaNicehash as secondary algo (unprofitable due to ASICs)
- ClaymoreDual AMD: added ' -y 1' option to disable Crossfire
