### PR TITLE
Display pool balances

### DIFF
--- a/API.psm1
+++ b/API.psm1
@@ -101,6 +101,10 @@
                     $Data = $API.WatchdogTimers | ConvertTo-Json
                     Break
                 }
+                "/balances" {
+                    $Data = $API.Balances | ConvertTo-Json
+                    Break
+                }
                 "/stop" {
                     $API.Stop = $true
                     $Data = "Stopping"

--- a/APIDocs.html
+++ b/APIDocs.html
@@ -34,6 +34,10 @@
     <a href="http://localhost:3999/pools">/pools</a>
     <p>Dump of the $Pools variable</p>
     
+    <h3>Pool Balances</h3>
+    <a href="http://localhost:3999/balances">/balances</a>
+    <p>Shows the balances at the pools</p>
+    
     <h3>NewPools</h3>
     <a href="http://localhost:3999/newpools">/newpools</a>
     <p>Dump of the $NewPools variable</p>

--- a/Balances/AHashPool.ps1
+++ b/Balances/AHashPool.ps1
@@ -1,0 +1,35 @@
+﻿using module ..\Include.psm1
+
+param(
+    $Config
+)
+
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$PoolConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if (!$PoolConfig.BTC) {
+    Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no wallet address specified."
+    return
+}
+
+try {
+    $Request = Invoke-RestMethod "http://www.ahashpool.com/api/wallet?address=$($PoolConfig.BTC)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+}
+catch {
+    Write-Log -Level Warn "Pool Balance API ($Name) has failed. "
+}
+
+if (($Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
+    Write-Log -Level Warn "Pool Balance API ($Name) returned nothing. "
+    return
+}
+
+[PSCustomObject]@{
+    "currency" = $Request.currency
+    "balance" = $Request.balance
+    "pending" = $Request.unsold
+    "total" = $Request.total_unpaid
+    'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Balances/BlazePool.ps1
+++ b/Balances/BlazePool.ps1
@@ -1,0 +1,35 @@
+﻿using module ..\Include.psm1
+
+param(
+    $Config
+)
+
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$PoolConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if (!$PoolConfig.BTC) {
+    Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no wallet address specified."
+    return
+}
+
+try {
+    $Request = Invoke-RestMethod "http://api.blazepool.com/wallet/$($PoolConfig.BTC)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+}
+catch {
+    Write-Log -Level Warn "Pool Balance API ($Name) has failed. "
+}
+
+if (($Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
+    Write-Log -Level Warn "Pool Balance API ($Name) returned nothing. "
+    return
+}
+
+[PSCustomObject]@{
+    "currency" = $Request.currency
+    "balance" = $Request.balance
+    "pending" = $Request.unsold
+    "total" = $Request.total_unpaid
+    'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Balances/HashRefinery.ps1
+++ b/Balances/HashRefinery.ps1
@@ -1,0 +1,35 @@
+﻿using module ..\Include.psm1
+
+param(
+    $Config
+)
+
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$PoolConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if (!$PoolConfig.BTC) {
+    Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no wallet address specified."
+    return
+}
+
+try {
+    $Request = Invoke-RestMethod "http://pool.hashrefinery.com/api/wallet?address=$($PoolConfig.BTC)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+}
+catch {
+    Write-Log -Level Warn "Pool Balance API ($Name) has failed. "
+}
+
+if (($Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
+    Write-Log -Level Warn "Pool Balance API ($Name) returned nothing. "
+    return
+}
+
+[PSCustomObject]@{
+    "currency" = $Request.currency
+    "balance" = $Request.balance
+    "pending" = $Request.unsold
+    "total" = $Request.unpaid
+    'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Balances/MiningPoolHub.ps1
+++ b/Balances/MiningPoolHub.ps1
@@ -1,0 +1,54 @@
+﻿using module ..\Include.psm1
+
+param($Config)
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$MyConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if(!$MyConfig.API_Key) {
+    Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no API key specified."
+    return
+}
+
+try {
+    $Request = Invoke-RestMethod "http://miningpoolhub.com/index.php?page=api&action=getuserallbalances&api_key=$($MyConfig.API_Key)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+    
+}
+catch {
+    Write-Warning "Pool API ($Name) has failed. "
+}
+
+if (($Request.getuserallbalances.data | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
+    return
+}
+
+# MiningPoolHub does balances a little differently from everyone else, returning the altcoin values directly
+# until they are exchanged. Convert them to 
+
+$altcointotal = [double]0
+$Request.getuserallbalances.data | Foreach-Object {
+    $coinname = $_.coin
+    # For coins that don't match the name on the exchange, fix up the coin name.
+    switch -wildcard ($_.coin) {
+        "bitcoin" {$coinname = 'BTC'}
+        "myriadcoin-*" {$coinname = 'myriad'}
+        "bitcoin-gold" {$coinname = 'Bitcoin Gold'}
+    }
+
+    # Convert the alt coins to BTC and add to pending balance
+    if($coinname -eq 'BTC') {
+        $balance = $_
+    } else {
+        $btcvalue = Get-BTCValue -altcoin $coinname -amount ($_.confirmed + $_.unconfirmed + $_.ae_confirmed + $_.ae_unconfirmed + $_.exchange)
+        $altcointotal += $btcvalue
+    }
+}
+[PSCustomObject]@{
+     'currency' = 'BTC'
+     'balance' = $balance.confirmed
+     'pending' = $balance.unconfirmed + $balance.ae_confirmed + $balance.ae_unconfirmed + $balance.exchange + $altcointotal
+     'total' = $balance.confirmed + $balance.unconfirmed + $balance.ae_confirmed + $balance.ae_unconfirmed + $balance.exchange + $altcointotal
+     'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Balances/Nicehash.ps1
+++ b/Balances/Nicehash.ps1
@@ -1,0 +1,36 @@
+using module ..\Include.psm1
+
+param(
+    $Config
+)
+
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$PoolConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if (!$PoolConfig.BTC) {
+    Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no wallet address specified."
+    return
+}
+
+try {
+    
+    #NH API does not total all of your balances for each algo up, so you have to do it with another call then total them manually.
+    $UnpaidRequest = Invoke-RestMethod "https://api.nicehash.com/api?method=stats.provider&addr=$($PoolConfig.BTC)"  -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+
+    $sum = 0
+    $UnpaidRequest.result.stats.balance | Foreach { $sum += $_}
+
+}
+catch {
+    Write-Log -Level Warn "Pool Balance API ($Name) has failed. "
+}
+
+[PSCustomObject]@{
+    "currency" = 'BTC'
+    "balance" = $sum
+    "pending" = 0 # Pending is always 0 since NiceHash doesn't report unconfirmed or unexchanged profits like other pools do
+    "total" = $sum
+    'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Balances/ZergPool.ps1
+++ b/Balances/ZergPool.ps1
@@ -1,0 +1,35 @@
+﻿using module ..\Include.psm1
+
+param(
+    $Config
+)
+
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$PoolConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if (!$PoolConfig.BTC) {
+    Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no wallet address specified."
+    return
+}
+
+try {
+    $Request = Invoke-RestMethod "http://zerg.zergpool.com/api/wallet?address=$($PoolConfig.BTC)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+}
+catch {
+    Write-Log -Level Warn "Pool Balance API ($Name) has failed. "
+}
+
+if (($Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
+    Write-Log -Level Warn "Pool Balance API ($Name) returned nothing. "
+    return
+}
+
+[PSCustomObject]@{
+    "currency" = $Request.currency
+    "balance" = $Request.balance
+    "pending" = $Request.unsold
+    "total" = $Request.unpaid
+    'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Balances/Zpool.ps1
+++ b/Balances/Zpool.ps1
@@ -1,0 +1,32 @@
+﻿using module ..\Include.psm1
+
+param($Config)
+$Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
+$MyConfig = $Config.Pools.$Name
+
+$Request = [PSCustomObject]@{}
+
+if(!$MyConfig.BTC) {
+  Write-Log -Level Verbose "Pool API ($Name) has failed - no wallet address specified."
+  return
+}
+
+try {
+    $Request = Invoke-RestMethod "http://zpool.ca/api/wallet?address=$($MyConfig.BTC)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+}
+catch {
+    Write-Log -Level Warn "Pool API ($Name) has failed. "
+}
+
+if (($Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {
+    Write-Log -Level Warn "Pool API ($Name) returned nothing. "
+    return
+}
+
+[PSCustomObject]@{
+  "currency" = $Request.currency
+  "balance" = $Request.balance
+  "pending" = $Request.unsold
+  "total" = $Request.unpaid
+  'lastupdated' = (Get-Date).ToUniversalTime()
+}

--- a/Config.default.txt
+++ b/Config.default.txt
@@ -41,5 +41,6 @@
   "MinerStatusURL": "$MinerStatusURL",
   "MinerStatusKey": "$MinerStatusKey",
   "SwitchingPrevention": "$SwitchingPrevention",
-  "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly"
+  "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
+  "ShowPoolBalances": "$ShowPoolBalances"
 }

--- a/Include.psm1
+++ b/Include.psm1
@@ -9,7 +9,7 @@ function Get-Balance {
     Write-Log "Getting pool balances"
 
     # If rates weren't specified, just use 1 BTC = 1 BTC
-    if($Rates -eq $Null) {
+    if ($Rates -eq $Null) {
         $Rates = [PSCustomObject]@{BTC = [Double]1}
     }
 
@@ -19,9 +19,10 @@ function Get-Balance {
     $Balances | Foreach-Object {
         Foreach($Rate in ($Rates.PSObject.Properties)) {
             # Round BTC to 8 decimals, everything else to 2
-            if($Rate.Name -eq "BTC") {
+            if ($Rate.Name -eq "BTC") {
                 $_ | Add-Member "Total_BTC" ("{0:N8}" -f ([Double]$Rate.Value * $_.total))
-            } else {
+            } 
+            else {
                 $_ | Add-Member "Total_$($Rate.Name)" ("{0:N2}" -f ([Double]$Rate.Value * $_.total))
             }
         }

--- a/Include.psm1
+++ b/Include.psm1
@@ -15,112 +15,18 @@ function Get-Balance {
 
     $balances = Get-ChildItemContent Balances -Parameters @{Config = $Config} | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
 
-    # Add local currency values if available
+    # Add local currency values
     $balances | Foreach-Object {
-        # Use balances in BTC as is.  Convert altcoins to BTC first.
-        if ($_.currency -eq 'BTC') {
-            $total = $_.total
-        } else {
-            $total = Get-BTCValue -altcoin $_.currency -amount $_.total
-        }
-
         Foreach($Rate in ($Rates.PSObject.Properties)) {
             # Round BTC to 8 decimals, everything else to 2
             if($Rate.Name -eq "BTC") {
-                $_ | Add-Member "Total_BTC" ("{0:N8}" -f ([Double]$Rate.Value * $total))
+                $_ | Add-Member "Total_BTC" ("{0:N8}" -f ([Double]$Rate.Value * $_.total))
             } else {
-                $_ | Add-Member "Total_$($Rate.Name)" ("{0:N2}" -f ([Double]$Rate.Value * $total))
+                $_ | Add-Member "Total_$($Rate.Name)" ("{0:N2}" -f ([Double]$Rate.Value * $_.total))
             }
         }
     }
-
     Return $balances
-}
-
-# Get-BTCValue gets the exchange rate from bittrex.com for various altcoins and returns an equivelent BTC value
-# Exchange rates are cached for 1 hour to avoid abusing their API
-function Get-BTCValue {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory=$true)][string]$altcoin,
-        [Parameter(Mandatory=$true)][double]$amount
-    )
-
-    if (-not (Test-Path "Cache")) {New-Item "Cache" -ItemType "directory" | Out-Null}
-    $filename = 'Cache\ExchangeRates.json'
-    $cachetime = New-TimeSpan -Hour 1
-    
-    $ExchangeRates = @{}
-    if(Test-Path $filename) {
-        $ExchangeRateData = Get-Content $filename | ConvertFrom-Json
-        # Turn the PSObject back into a hashtable
-        $ExchangeRateData.PSObject.Properties | Foreach {$ExchangeRates[$_.Name] = $_.Value}
-    }
-    
-    # Return a cached exchange rate if available
-    if($ExchangeRates[$altcoin].LastUpdated -and ((Get-Date) - $ExchangeRates[$altcoin].LastUpdated) -lt $cachetime -and $ExchangeRates[$altcoin].rate -ne $null) {
-        Write-Log -Level Debug "Using cached exchange rate for $altcoin"
-        Return $amount * $ExchangeRates[$altcoin].rate
-    }
-    
-    # If there is no cached exchange rate, find the market for the coin and get the exchange rate
-    $market = Get-BittrexMarketName -altcoin $altcoin
-    if($market -eq $NULL) {
-        Write-Log -Level Verbose "Unable to get market for $altcoin"
-    } else {
-        Write-Log -Level Debug "Updating exchange rate for $altcoin"
-        try {
-            $Request = Invoke-RestMethod "https://bittrex.com/api/v1.1/public/getticker?market=$($market)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
-        } catch {
-            Write-Log -Level Warn "Bittrex exchange API has failed."
-            Return 0
-        }
-    }
-
-    # Write the new exchange rate to the cache
-    $ExchangeRates[$altcoin] = @{'rate' = $Request.result.Last; 'lastupdated' = (Get-Date).ToUniversalTime()}
-    $Exchangerates | ConvertTo-Json | Set-Content $filename
-
-    Return $ExchangeRates[$altcoin].rate * $amount
-}
-
-# Get-BittrexMarketName returns the altcoin<->BTC market name for a particular coin. Used by Get-BTCValue
-# It caches the markets list for 1 day to avoid abusing their API
-function Get-BittrexMarketName {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory=$true)][string]$altcoin
-    )
-    
-    if (-not (Test-Path "Cache")) {New-Item "Cache" -ItemType "directory" | Out-Null}
-    $cachefile = 'Cache\BittrexMarkets.json'
-    
-    $markets = $NULL
-    
-    if(Test-Path $cachefile) {
-        $lastupdated = (Get-Item $cachefile).LastWriteTime
-        $timespan = New-TimeSpan -Days 1
-        if(((Get-Date) - $lastupdated) -lt $timespan) {
-            Write-Log -Level Verbose "Using cached market list"
-            $markets = Get-Content $cachefile | ConvertFrom-Json
-        }
-    }
-    
-    # Update market file if necessary
-    if ($markets -eq $NULL) {
-        Write-Log -Level Verbose "Updating Bittrex markets list"
-        try {
-            $Request = Invoke-RestMethod "https://bittrex.com/api/v1.1/public/getmarkets" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
-            $markets = $Request.result | Where-Object {$_.BaseCurrency -eq 'BTC'}
-            $markets | ConvertTo-Json | Set-Content $cachefile
-        } catch {
-            Write-Log -Level Warn "Bittrex exchange API has failed."
-            Return $false
-        }
-    }
-
-    $altcoinmarket = $markets | Where-Object {$_.MarketCurrencyLong -eq $altcoin -or $_.MarketCurrency -eq $altcoin} | Select-Object -First 1
-    Return $altcoinmarket.MarketName
 }
 
 function Get-Devices {

--- a/Include.psm1
+++ b/Include.psm1
@@ -13,10 +13,10 @@ function Get-Balance {
         $Rates = [PSCustomObject]@{BTC = [Double]1}
     }
 
-    $balances = Get-ChildItemContent Balances -Parameters @{Config = $Config} | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
+    $Balances = Get-ChildItemContent Balances -Parameters @{Config = $Config} | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
 
     # Add local currency values
-    $balances | Foreach-Object {
+    $Balances | Foreach-Object {
         Foreach($Rate in ($Rates.PSObject.Properties)) {
             # Round BTC to 8 decimals, everything else to 2
             if($Rate.Name -eq "BTC") {
@@ -26,7 +26,7 @@ function Get-Balance {
             }
         }
     }
-    Return $balances
+    Return $Balances
 }
 
 function Get-Devices {

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -176,7 +176,7 @@ while ($true) {
             SwitchingPrevention        = $SwitchingPrevention
             ShowMinerWindow            = $ShowMinerWindow
             UseFastestMinerPerAlgoOnly = $UseFastestMinerPerAlgoOnly
-            ShowPoolBalances         = $ShowPoolBalances
+            ShowPoolBalances           = $ShowPoolBalances
             IgnoreMinerFee             = $IgnoreMinerFee
         } | Select-Object -ExpandProperty Content
     }
@@ -689,7 +689,7 @@ while ($true) {
     #Display pool balances, formatting it to show all the user specified currencies
     if ($Config.ShowPoolBalances) {
         Write-Host "Pool Balances: "
-        $balances | Format-Table Name, Total_*
+        $Balances | Format-Table Name, Total_*
     }
 
     #Display benchmarking progress


### PR DESCRIPTION
This gets pool balances, making them available in the API and optionally displayed in the script output.

Most pools return values in BTC, and get shown as is, as well as in any local currencies specified.  MiningPoolHub does a bit more work, loading exchange rates from Bittrex to get the BTC equivalent of all unconverted coins as well.  The exchange rates are cached for an hour because hammering Bittrex's API too often will cause IP bans.

Add '-showpoolbalances' to your start.bat or set the setting to true in default.txt to see the balances.

This is also needed for a more advanced monitoring site I am working on which will report pool balances, because I want it to be able to track pool balances and compare your estimated earnings to actual ones.

Closes #1100