### PR TITLE
Fix Get-Balances

### DIFF
--- a/Config.default.txt
+++ b/Config.default.txt
@@ -42,6 +42,7 @@
   "MinerStatusKey": "$MinerStatusKey",
   "SwitchingPrevention": "$SwitchingPrevention",
   "ShowPoolBalances": "$ShowPoolBalances",
+  "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
   "ExtendIntervalAlgorithm": [
     "X16R",
     "X16S"

--- a/Include.psm1
+++ b/Include.psm1
@@ -13,7 +13,7 @@ function Get-Balance {
         $Rates = [PSCustomObject]@{BTC = [Double]1}
     }
     
-    $Balances = Get-ChildItem "Balances" -File | Where-Object {$Config.Pools.$($_.BaseName) -and $Config.ExcludePoolName -inotcontains $_.BaseName} | ForEach-Object {
+    $Balances = Get-ChildItem "Balances" -File | Where-Object {$Config.Pools.$($_.BaseName) -and ($Config.ExcludePoolName -inotcontains $_.BaseName) -or $Config.ShowPoolBalancesExcludedPools} | ForEach-Object {
         Get-ChildItemContent "Balances\$($_.Name)" -Parameters @{Config = $Config}
     } | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
 

--- a/Include.psm1
+++ b/Include.psm1
@@ -17,6 +17,12 @@ function Get-Balance {
         Get-ChildItemContent "Balances\$($_.Name)" -Parameters @{Config = $Config}
     } | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
 
+    # Add total of totals
+    $Balances += [PSCustomObject]@{
+        total = ($Balances.total | Measure-Object -Sum).sum
+        Name  = "*Total*"
+    }
+
     # Add local currency values
     $Balances | Foreach-Object {
         Foreach($Rate in ($Rates.PSObject.Properties)) {

--- a/Include.psm1
+++ b/Include.psm1
@@ -12,18 +12,20 @@ function Get-Balance {
     if ($Rates -eq $Null) {
         $Rates = [PSCustomObject]@{BTC = [Double]1}
     }
-
-    $Balances = Get-ChildItemContent Balances -Parameters @{Config = $Config} | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
+    
+    $Balances = Get-ChildItem "Balances" -File | Where-Object {$Config.Pools.$($_.BaseName) -and $Config.ExcludePoolName -inotcontains $_.BaseName} | ForEach-Object {
+        Get-ChildItemContent "Balances\$($_.Name)" -Parameters @{Config = $Config}
+    } | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru}
 
     # Add local currency values
     $Balances | Foreach-Object {
         Foreach($Rate in ($Rates.PSObject.Properties)) {
-            # Round BTC to 8 decimals, everything else to 2
+            # Round BTC to 8 decimals, everything else is based on BTC value
             if ($Rate.Name -eq "BTC") {
                 $_ | Add-Member "Total_BTC" ("{0:N8}" -f ([Double]$Rate.Value * $_.total))
-            } 
+            }
             else {
-                $_ | Add-Member "Total_$($Rate.Name)" ("{0:N2}" -f ([Double]$Rate.Value * $_.total))
+                $_ | Add-Member "Total_$($Rate.Name)" (ConvertTo-LocalCurrency $($_.total) $Rate.Value -Offset 4)
             }
         }
     }
@@ -505,7 +507,8 @@ function ConvertTo-LocalCurrency {
         6 {$Number.ToString("N6")}
         7 {$Number.ToString("N7")}
         8 {$Number.ToString("N8")}
-        Default {$Number.ToString("N9")}
+        9 {$Number.ToString("N9")}
+        Default {$Number.ToString("N0")}
     }
 }
 

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -68,8 +68,11 @@ param(
     [Parameter(Mandatory = $false)]
     [Switch]$UseFastestMinerPerAlgoOnly = $false, #Use only use fastest miner per algo and device index. E.g. if there are 2 miners available to mine the same algo, only the faster of the two will ever be used, the slower ones will also be hidden in the summary screen
     [Parameter(Mandatory = $false)]
-    [Switch]$ShowPoolBalances = $false,
     [Switch]$IgnoreMinerFee = $false # If $true MPM will ignore miner fees for its calculations (as older versions did)
+    [Parameter(Mandatory = $false)]
+    [Switch]$ShowPoolBalances = $false,
+    [Parameter(Mandatory = $false)]
+    $ShowPoolBalancesForExcludedPools = $false    
 )
 
 Clear-Host
@@ -149,35 +152,36 @@ while ($true) {
     $ConfigBackup = $Config
     if (Test-Path "Config.txt") {
         $Config = Get-ChildItemContent "Config.txt" -Parameters @{
-            Wallet                     = $Wallet
-            UserName                   = $UserName
-            WorkerName                 = $WorkerName
-            API_ID                     = $API_ID
-            API_Key                    = $API_Key
-            Interval                   = $Interval
-            ExtendIntervalAlgorithm    = $ExtendIntervalAlgorithm
-            ExtendIntervalMinerName    = $ExtendIntervalMinerName
-            Region                     = $Region
-            SSL                        = $SSL
-            Type                       = $Type
-            Algorithm                  = $Algorithm
-            MinerName                  = $MinerName
-            PoolName                   = $PoolName
-            ExcludeAlgorithm           = $ExcludeAlgorithm
-            ExcludeMinerName           = $ExcludeMinerName
-            ExcludePoolName            = $ExcludePoolName
-            Currency                   = $Currency
-            Donate                     = $Donate
-            Proxy                      = $Proxy
-            Delay                      = $Delay
-            Watchdog                   = $Watchdog
-            MinerStatusURL             = $MinerStatusURL
-            MinerStatusKey             = $MinerStatusKey
-            SwitchingPrevention        = $SwitchingPrevention
-            ShowMinerWindow            = $ShowMinerWindow
-            UseFastestMinerPerAlgoOnly = $UseFastestMinerPerAlgoOnly
-            ShowPoolBalances           = $ShowPoolBalances
-            IgnoreMinerFee             = $IgnoreMinerFee
+            Wallet                        = $Wallet
+            UserName                      = $UserName
+            WorkerName                    = $WorkerName
+            API_ID                        = $API_ID
+            API_Key                       = $API_Key
+            Interval                      = $Interval
+            ExtendIntervalAlgorithm       = $ExtendIntervalAlgorithm
+            ExtendIntervalMinerName       = $ExtendIntervalMinerName
+            Region                        = $Region
+            SSL                           = $SSL
+            Type                          = $Type
+            Algorithm                     = $Algorithm
+            MinerName                     = $MinerName
+            PoolName                      = $PoolName
+            ExcludeAlgorithm              = $ExcludeAlgorithm
+            ExcludeMinerName              = $ExcludeMinerName
+            ExcludePoolName               = $ExcludePoolName
+            Currency                      = $Currency
+            Donate                        = $Donate
+            Proxy                         = $Proxy
+            Delay                         = $Delay
+            Watchdog                      = $Watchdog
+            MinerStatusURL                = $MinerStatusURL
+            MinerStatusKey                = $MinerStatusKey
+            SwitchingPrevention           = $SwitchingPrevention
+            ShowMinerWindow               = $ShowMinerWindow
+            UseFastestMinerPerAlgoOnly    = $UseFastestMinerPerAlgoOnly
+            IgnoreMinerFee                = $IgnoreMinerFee
+            ShowPoolBalances              = $ShowPoolBalances
+            ShowPoolBalancesExcludedPools = $ShowPoolBalancesForExcludedPools
         } | Select-Object -ExpandProperty Content
     }
 
@@ -264,8 +268,10 @@ while ($true) {
     }
 
     #Update the pool balances
-    $Balances = Get-Balance -Config $UserConfig -Rates $Rates
-    $API.Balances = $Balances
+    if ($Config.ShowPoolBalances -or $Config.ShowPoolBalancesExcludedPools) {
+        $Balances = Get-Balance -Config $UserConfig -Rates $Rates
+        $API.Balances = $Balances
+    }
 
     #Load the stats
     Write-Log "Loading saved statistics. "
@@ -687,7 +693,7 @@ while ($true) {
     }
 
     #Display pool balances, formatting it to show all the user specified currencies
-    if ($Config.ShowPoolBalances) {
+    if ($Config.ShowPoolBalances -or $Config.ShowPoolBalancesExcludedPools) {
         Write-Host "Pool Balances: "
         $Balances | Format-Table Name, Total_*
     }


### PR DESCRIPTION
- do not retrieve balances for excluded pools (fix for #1780)
- dynamic decimal digits for non-BTC currencies
- add '\*Total\*' row:
- add $ShowPoolBalancesExcludedPools
- do not retrieve balances if neither
$ShowPoolBalances nor $ShowPoolBalancesExcludedPools is $true.
This avoids unnecessary API queries and is also fixes a conflict where $API.Balances would be partly filled (active pools) if neither parameter is $true

```
Name          Total_CHF Total_BTC  Total_USD
----          --------- ---------  ---------
AHashPool     nn.nn     n.nnnnnnnn nn.nn
BlazePool     nn.nn     n.nnnnnnnn nn.nn
HashRefinery  nn.nn     n.nnnnnnnn nn.nn
MiningPoolHub nn.nn     n.nnnnnnnn nn.nn
Nicehash      nn.nn     n.nnnnnnnn nn.nn
ZergPool      nn.nn     n.nnnnnnnn nn.nn
Zpool         nn.nn     n.nnnnnnnn nn.nn
*Total*       123.45    0.12345678 123.45
```