### PR TITLE
Dynamic ExtendInterval

### DIFF
--- a/Config.default.txt
+++ b/Config.default.txt
@@ -43,15 +43,15 @@
   "SwitchingPrevention": "$SwitchingPrevention",
   "ShowPoolBalances": "$ShowPoolBalances",
   "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
-  "ExtendIntervalAlgorithm": [
-    "X16R:10",
-    "X16S:10"
-  ],
-  "ExtendIntervalMinerName": [
-    "PalginNvidia:3",
-    "Excavator:3",
-    "Bminer:3"
-  ],
+  "ExtendIntervalAlgorithm": {
+    "X16R": 5,
+    "X16S": 5
+  },
+  "ExtendIntervalMinerName": {
+    "PalginNvidia": 3,
+    "BMiner": 3,
+    "Excavator": 3
+  },
   "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
   "IgnoreMinerFee":  "$IgnoreMinerFee"
 }

--- a/Config.default.txt
+++ b/Config.default.txt
@@ -44,11 +44,13 @@
   "ShowPoolBalances": "$ShowPoolBalances",
   "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
   "ExtendIntervalAlgorithm": [
-    "X16R",
-    "X16S"
+    "X16R:10",
+    "X16S:10"
   ],
   "ExtendIntervalMinerName": [
-    "PalginNvidia"
+    "PalginNvidia:3",
+    "Excavator:3",
+    "Bminer:3"
   ],
   "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
   "IgnoreMinerFee":  "$IgnoreMinerFee"

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -18,9 +18,9 @@ param(
     [Parameter(Mandatory = $false)]
     [Int]$Interval = 60, #seconds before reading hash rate from miners
     [Parameter(Mandatory = $false)]
-    [Array]$ExtendIntervalAlgorithm = @("X16R:10", "X16S:10"), #Extend interval duration by :n times $Interval for these algorithms
+    [Array]$ExtendIntervalAlgorithm = [PSCustomObject]@{"X16R" = 10; "X16S" = 10}, #Extend interval duration by n times $Interval for these algorithms
     [Parameter(Mandatory = $false)]
-    [Array]$ExtendIntervalMinerName = @("PalginNvidia:3", "Excavator:3", "Bminer:3"), #Extend interval duration by :n times $Interval for these miners
+    [Array]$ExtendIntervalMinerName = [PSCustomObject]@{"PalginNvidia" = 3; "Excavator" = 3; "Bminer" = 3}, #Extend interval duration by n times $Interval for these miners
     [Parameter(Mandatory = $false)]
     [Alias("Location")]
     [String]$Region = "europe", #europe/us/asia

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -722,11 +722,11 @@ while ($true) {
     #When benchmarking miners/algorithm in ExtendInterval...
     $Multiplier = 0
     $RunningMiners | Where-Object {$_.Speed -eq $null} | ForEach-Object {
-        if ($Config.ExtendIntervalMinerName.($_.Name)) {
-            if ($Config.ExtendIntervalMinerName.($_.Name) -gt $Multiplier) {$Multiplier = $Config.ExtendIntervalMinerName.($_.Name)} else {$Multiplier = 10}
+        if ($MatchingMinerName = $Config.ExtendIntervalMinerName.psobject.properties.name -match "^$($_.Name -Split "-" | Select-Object -Index 0)") {
+            if ($Config.ExtendIntervalMinerName.$MatchingMinerName -ge $Multiplier) {$Multiplier = $Config.ExtendIntervalMinerName.$MatchingMinerName} else {$Multiplier = 10}
         }
-        $_.Algorithm | Where-Object {$Config.ExtendIntervalAlgorithm.psobject.properties.match("$_")} | ForEach-Object {
-            if ($Config.ExtendIntervalAlgorithm.$_ -gt $Multiplier) {$Multiplier = $Config.ExtendIntervalAlgorithm.$_} else {$Multiplier = 10}
+        $_.Algorithm | Where-Object {$Config.ExtendIntervalAlgorithm.psobject.properties.name -match $_} | ForEach-Object {
+            if ($Config.ExtendIntervalAlgorithm.$_ -ge $Multiplier) {$Multiplier = $Config.ExtendIntervalAlgorithm.$_} else {$Multiplier = 10}
         }
     }
     #Multiply $Config.Interval and add it to $StatEnd, extend StatSpan, extend watchdog times
@@ -771,7 +771,7 @@ while ($true) {
                 if ($Miner.New -and (-not $Miner_Speed)) {$Miner_Speed = $Miner.GetHashRate($_, ($Interval * $Miner.Benchmarked), ($Miner.Benchmarked -lt $Strikes))}
 
                 if ((-not $Miner.New) -or $Miner_Speed -or $Miner.Benchmarked -ge ($Strikes * $Strikes) -or $Miner.GetActivateCount() -ge $Strikes) {
-                    $Stat = Set-Stat -Name "$($Miner.Name)_$($_)_HashRate" -Value $Miner_Speed -Duration $StatSpan -FaultDetection ($Config.ExtendIntervalMinerName -notmatch "^$($Miner.Name)" -and $Config.ExtendIntervalAlgorithm  -notmatch "^$($_)")
+                    $Stat = Set-Stat -Name "$($Miner.Name)_$($_)_HashRate" -Value $Miner_Speed -Duration $StatSpan -FaultDetection (-not ($Config.ExtendIntervalMinerName.psobject.properties.Name -match "^$($Miner.Name -Split "-" | Select-Object -Index 0)" -or $Config.ExtendIntervalAlgorithm.psobject.properties.name -match "^$($_)"))
                 }
 
                 #Update watchdog timer

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -722,15 +722,16 @@ while ($true) {
     #When benchmarking miners/algorithm in ExtendInterval...
     $Multiplier = 0
     $RunningMiners | Where-Object {$_.Speed -eq $null} | ForEach-Object {
-        if ($MinerNameMatch = ($Config.ExtendIntervalMinerName -match "^$($_)")) {
-            $Multiplier = if (($MinerNameMatch -split ":" | Select-Object -Index 1) -gt $Multiplier) {$MinerNameMatch -split ":" | Select-Object -Index 1} else {$Multiplier = 10}
+        if ($Config.ExtendIntervalMinerName.($_.Name)) {
+            if ($Config.ExtendIntervalMinerName.($_.Name) -gt $Multiplier) {$Multiplier = $Config.ExtendIntervalMinerName.($_.Name)} else {$Multiplier = 10}
         }
-        if ($AlgorithmMatch = ($_.Algorithm | Where-Object {$Config.ExtendIntervalAlgorithm -match "^$($_)"})) {
-            $Multiplier = if (($AlgorithmMatch -split ":" | Select-Object -Index 1) -gt $Multiplier) {$AlgorithmMatch -split ":" | Select-Object -Index 1} else {$Multiplier = 10}
+        $_.Algorithm | Where-Object {$Config.ExtendIntervalAlgorithm.psobject.properties.match("$_")} | ForEach-Object {
+            if ($Config.ExtendIntervalAlgorithm.$_ -gt $Multiplier) {$Multiplier = $Config.ExtendIntervalAlgorithm.$_} else {$Multiplier = 10}
         }
     }
     #Multiply $Config.Interval and add it to $StatEnd, extend StatSpan, extend watchdog times
     if ($Multiplier -gt 0) {
+        if ($Multiplier -gt 10) {$Multiplier = 10}
         $StatEnd = $StatEnd.AddSeconds($Config.Interval * $Multiplier)
         $StatSpan = New-TimeSpan $StatStart $StatEnd
         $WatchdogInterval = ($WatchdogInterval / $Strikes * ($Strikes - 1)) + $StatSpan.TotalSeconds

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ###### Licensed under the GNU General Public License v3.0 - Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/LICENSE
 
-README.md is based on README.txt - updated on 30/05/2018 - v1.05.30 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
+README.md is based on README.txt - updated on 08/06/2018 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ###### Licensed under the GNU General Public License v3.0 - Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/LICENSE
 
-README.md is based on README.txt - updated on 26/05/2018 - v1.23.06 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
+README.md is based on README.txt - updated on 30/05/2018 - v1.05.30 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
 
 
 
@@ -158,10 +158,10 @@ Choose the default currency or currencies your profit stats will be shown in.
 MultiPoolMiner's update interval in seconds. This is a universal timer for running the entire script (downloading/processing APIs, calculation etc).  It also determines how long a benchmark is run for each miner file (miner/algorithm/coin). Default is 60.
 
 **-ExtendIntervalAlgorithm**
-	Extend interval timer duration by a factor of 10x $Interval for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R", "X16S").
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
 	
-**-ExtendIntervalMinerName**
-	Extend interval timer duration by a factor of 10x $Interval for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia").
+**-ExtendIntervalMinerName:IntervalMultiplier**
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3","Excavator:3","Bminer:3").
 
 **-delay**
 Specify the number of seconds required to pass before opening each miner. It is useful when cards are more sensitive to switching and need some extra time to recover (eg. clear DAG files from memory)
@@ -202,6 +202,12 @@ Use only use fastest miner per algo and device index. E.g. if there are 2 or mor
 **-IgnoreMinerFee**
 Newer versions of MPM take miner fees into account when calculating profitability. Set this flag to 'true' to ignore the fees (old MPM behaviour).
 This is also a per-miner configuration item which available through advanced configuration 
+
+**ShowPoolBalances**
+Set to 'true' to have the balances of all active pools displayed on the summary screen.
+	
+**ShowPoolBalancesExcludedPools**
+Set to 'true' to have the balances of all pools (including those that are excluded with 'ExcludeMinerName') displayed on the summary screen.
 
     
 ##SAMPLE USAGE
@@ -271,8 +277,6 @@ Warning: The JSON file structure is very fragile - every comma counts, so be car
   "Miners": {
   },
   "Interval": "$Interval",
-  "ExtendIntervalAlgorithm": "ExtendIntervalAlgorithm",
-  "ExtendIntervalMinerName: "ExtendIntervalMinerName",
   "Region": "$Region",
   "SSL": "$SSL",
   "Type": "$Type",
@@ -291,6 +295,17 @@ Warning: The JSON file structure is very fragile - every comma counts, so be car
   "MinerStatusKey": "$MinerStatusKey",
   "SwitchingPrevention": "$SwitchingPrevention",
   "ShowMinerWindow": "$ShowMinerWindow",
+  "ShowPoolBalances": "$ShowPoolBalances",
+  "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
+  "ExtendIntervalAlgorithm": [
+    "X16R:10",
+    "X16S:10"
+  ],
+  "ExtendIntervalMinerName": [
+    "PalginNvidia:3",
+    "Excavator:3",
+    "Bminer:3"
+  ],
   "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
   "IgnoreMinerFee":  "$IgnoreMinerFee"
 }

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ Choose the default currency or currencies your profit stats will be shown in.
 MultiPoolMiner's update interval in seconds. This is a universal timer for running the entire script (downloading/processing APIs, calculation etc).  It also determines how long a benchmark is run for each miner file (miner/algorithm/coin). Default is 60.
 
 **-ExtendIntervalAlgorithm**
-	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is [PSCustomObject{"X16R" = 10; "X16S" = 10}.
 	
 **-ExtendIntervalMinerName:IntervalMultiplier**
-	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3", "Excavator:3", "Bminer:3").
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is [PSCustomObject]@{"PalginNvidia": 3; "Excavator" = 3; "Bminer" = 3}.
 
 **-delay**
 Specify the number of seconds required to pass before opening each miner. It is useful when cards are more sensitive to switching and need some extra time to recover (eg. clear DAG files from memory)
@@ -297,15 +297,15 @@ Warning: The JSON file structure is very fragile - every comma counts, so be car
   "ShowMinerWindow": "$ShowMinerWindow",
   "ShowPoolBalances": "$ShowPoolBalances",
   "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
-  "ExtendIntervalAlgorithm": [
-    "X16R:10",
-    "X16S:10"
-  ],
-  "ExtendIntervalMinerName": [
-    "PalginNvidia:3",
-    "Excavator:3",
-    "Bminer:3"
-  ],
+  "ExtendIntervalAlgorithm": {
+    "X16R": 5,
+    "X16S": 5
+  },
+  "ExtendIntervalMinerName": {
+    "PalginNvidia": 3,
+    "BMiner": 3,
+    "Excavator": 3
+  },
   "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
   "IgnoreMinerFee":  "$IgnoreMinerFee"
 }

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ Choose the default currency or currencies your profit stats will be shown in.
 **-interval**
 MultiPoolMiner's update interval in seconds. This is a universal timer for running the entire script (downloading/processing APIs, calculation etc).  It also determines how long a benchmark is run for each miner file (miner/algorithm/coin). Default is 60.
 
-**-ExtendIntervalAlgorithm**
+**-ExtendIntervalAlgorithm([PSCustomObject]@{Algorithm1=Factor1;Algorithm2=Factor2;...})**
 	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is [PSCustomObject{"X16R" = 10; "X16S" = 10}.
 	
-**-ExtendIntervalMinerName:IntervalMultiplier**
+**-ExtendIntervalMinerName([PSCustomObject]@{MinerName1=Factor1;MinerName2=Factor2;...})**
 	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is [PSCustomObject]@{"PalginNvidia": 3; "Excavator" = 3; "Bminer" = 3}.
 
 **-delay**

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ MultiPoolMiner's update interval in seconds. This is a universal timer for runni
 	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
 	
 **-ExtendIntervalMinerName:IntervalMultiplier**
-	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3","Excavator:3","Bminer:3").
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3", "Excavator:3", "Bminer:3").
 
 **-delay**
 Specify the number of seconds required to pass before opening each miner. It is useful when cards are more sensitive to switching and need some extra time to recover (eg. clear DAG files from memory)

--- a/README.txt
+++ b/README.txt
@@ -17,7 +17,7 @@ TWITTER: @multipoolminer
 Licensed under the GNU General Public License v3.0
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/LICENSE
 
-README.txt - updated on 30/05/2018 (dd/mm/yyyy) - v1.05.30 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
+README.txt - updated on 08/06/2018 (dd/mm/yyyy) - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
 
 
 ====================================================================

--- a/README.txt
+++ b/README.txt
@@ -169,10 +169,10 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -interval
 	MultiPoolMiner's update interval in seconds. This is a universal timer for running the entire script (downloading/processing APIs, calculation etc).  It also determines how long a benchmark is run for each miner file (miner/algorithm/coin). Default is 60.
 
--ExtendIntervalAlgorithm
+-ExtendIntervalAlgorithm([PSCustomObject]@{Algorithm1=Factor1;Algorithm2=Factor2;...})
 	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is [PSCustomObject{"X16R" = 10; "X16S" = 10}.
 	
--ExtendIntervalMinerName:IntervalMultiplier
+-ExtendIntervalMinerName([PSCustomObject]@{MinerName1=Factor1;MinerName2=Factor2;...})
 	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is [PSCustomObject]@{"PalginNvidia": 3; "Excavator" = 3; "Bminer" = 3}.
     
 -delay

--- a/README.txt
+++ b/README.txt
@@ -173,7 +173,7 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
 	
 -ExtendIntervalMinerName:IntervalMultiplier
-	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3","Excavator:3","Bminer:3").
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3", "Excavator:3", "Bminer:3").
     
 -delay
 	Specify the number of seconds required to pass before opening each miner. It is useful if cards are sensitive to switching and need some extra time to recover (eg. clear DAG files from memory)

--- a/README.txt
+++ b/README.txt
@@ -169,11 +169,11 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -interval
 	MultiPoolMiner's update interval in seconds. This is a universal timer for running the entire script (downloading/processing APIs, calculation etc).  It also determines how long a benchmark is run for each miner file (miner/algorithm/coin). Default is 60.
 
--ExtendIntervalAlgorithm:IntervalMultiplier
-	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
+-ExtendIntervalAlgorithm
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is [PSCustomObject{"X16R" = 10; "X16S" = 10}.
 	
 -ExtendIntervalMinerName:IntervalMultiplier
-	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3", "Excavator:3", "Bminer:3").
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is $null IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is [PSCustomObject]@{"PalginNvidia": 3; "Excavator" = 3; "Bminer" = 3}.
     
 -delay
 	Specify the number of seconds required to pass before opening each miner. It is useful if cards are sensitive to switching and need some extra time to recover (eg. clear DAG files from memory)
@@ -312,15 +312,15 @@ Default content of 'Config.txt'
   "ShowMinerWindow": "$ShowMinerWindow",
   "ShowPoolBalances": "$ShowPoolBalances",
   "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
-  "ExtendIntervalAlgorithm": [
-    "X16R:10",
-    "X16S:10"
-  ],
-  "ExtendIntervalMinerName": [
-    "PalginNvidia:3",
-    "Excavator:3",
-    "Bminer:3"
-  ],
+  "ExtendIntervalAlgorithm": {
+    "X16R": 5,
+    "X16S": 5
+  },
+  "ExtendIntervalMinerName": {
+    "PalginNvidia": 3,
+    "BMiner": 3,
+    "Excavator": 3
+  },
   "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
   "IgnoreMinerFee":  "$IgnoreMinerFee"
 }

--- a/README.txt
+++ b/README.txt
@@ -17,7 +17,7 @@ TWITTER: @multipoolminer
 Licensed under the GNU General Public License v3.0
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/LICENSE
 
-README.txt - updated on 26/05/2018 (dd/mm/yyyy) - v1.23.06 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
+README.txt - updated on 30/05/2018 (dd/mm/yyyy) - v1.05.30 - latest version can be found here: https://github.com/MultiPoolMiner/MultiPoolMiner/blob/master/README.txt
 
 
 ====================================================================
@@ -169,11 +169,11 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -interval
 	MultiPoolMiner's update interval in seconds. This is a universal timer for running the entire script (downloading/processing APIs, calculation etc).  It also determines how long a benchmark is run for each miner file (miner/algorithm/coin). Default is 60.
 
--ExtendIntervalAlgorithm
-	Extend interval timer duration by a factor of 10x $Interval for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R", "X16S").
+-ExtendIntervalAlgorithm:IntervalMultiplier
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
 	
--ExtendIntervalMinerName
-	Extend interval timer duration by a factor of 10x $Interval for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia").
+-ExtendIntervalMinerName:IntervalMultiplier
+	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3","Excavator:3","Bminer:3").
     
 -delay
 	Specify the number of seconds required to pass before opening each miner. It is useful if cards are sensitive to switching and need some extra time to recover (eg. clear DAG files from memory)
@@ -213,6 +213,12 @@ COMMAND LINE OPTIONS (case-insensitive - except for BTC addresses, see Sample Us
 -IgnoreMinerFee
 	Newer versions of MPM take miner fees into account when calculating profitability. Set this flag to 'true' to ignore the fees (old MPM behaviour).
 	This is also a per-miner configuration item which available through advanced configuration 
+
+-ShowPoolBalances
+	Set to 'true' to have the balances of all active pools displayed on the summary screen.
+	
+-ShowPoolBalancesExcludedPools
+	Set to 'true' to have the balances of all pools (including those that are excluded with 'ExcludeMinerName') displayed on the summary screen.
 
 
 ====================================================================
@@ -286,8 +292,6 @@ Default content of 'Config.txt'
   "Miners": {
   },
   "Interval": "$Interval",
-  "ExtendIntervalAlgorithm": "ExtendIntervalAlgorithm",
-  "ExtendIntervalMinerName: "ExtendIntervalMinerName",
   "Region": "$Region",
   "SSL": "$SSL",
   "Type": "$Type",
@@ -306,6 +310,17 @@ Default content of 'Config.txt'
   "MinerStatusKey": "$MinerStatusKey",
   "SwitchingPrevention": "$SwitchingPrevention",
   "ShowMinerWindow": "$ShowMinerWindow",
+  "ShowPoolBalances": "$ShowPoolBalances",
+  "ShowPoolBalancesExcludedPools": "$ShowPoolBalancesExcludedPools",
+  "ExtendIntervalAlgorithm": [
+    "X16R:10",
+    "X16S:10"
+  ],
+  "ExtendIntervalMinerName": [
+    "PalginNvidia:3",
+    "Excavator:3",
+    "Bminer:3"
+  ],
   "UseFastestMinerPerAlgoOnly": "$UseFastestMinerPerAlgoOnly",
   "IgnoreMinerFee":  "$IgnoreMinerFee"
 }


### PR DESCRIPTION
**Made ExtendInterval more flexible, yet backwards compatible with previous code**
See https://github.com/MultiPoolMiner/MultiPoolMiner/pull/1682

-ExtendIntervalAlgorithm:IntervalMultiplier
	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified algorithms. Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration. Default is @("X16R:10", "X16S:10").
	
-ExtendIntervalMinerName:IntervalMultiplier
	When benchmarking extend interval timer duration by :IntervalMultiplier times (if IntervalMultiplier is omitted IntervalMultiplier will be set to 10) for specified miners. Due to their nature some miners, e.g. 'PalginNvidia', will always trigger watchdog on normal interval duration. Default is @("PalginNvidia:3", "Excavator:3", "Bminer:3").
