### PR TITLE
Don't accidentally print the path

### DIFF
--- a/API.psm1
+++ b/API.psm1
@@ -10,7 +10,7 @@
     $newRunspace = [runspacefactory]::CreateRunspace()
     $newRunspace.Open()
     $newRunspace.SessionStateProxy.SetVariable("API", $API)
-    $newRunspace.SessionStateProxy.Path.SetLocation($(pwd))
+    $newRunspace.SessionStateProxy.Path.SetLocation($(pwd)) | Out-Null
 
     $apiserver = [PowerShell]::Create().AddScript({
 


### PR DESCRIPTION
I finally found where the path being printed on the first loop in between some of the output came from.

Why it waits until near the bottom of the loop to print it, when the code that made it be printed was before the loop even started beats me, but this is definitely where it was coming from.