### PR TITLE
Change API to serve files as well

### DIFF
--- a/web/APIDocs.html
+++ b/web/APIDocs.html
@@ -4,6 +4,13 @@
     
     API data is available at http://localhost:3999/&lt;resource&gt;
 
+    <h2>File and Scripts</h2>
+    <p>Anything other than the resources listed below will be looked for in the web directory and sent if it exists.</p>
+    
+    <p>Any .ps1 files in the web directory will be run and their output sent. They get passed a $Parameters object with keys and values from the URL string.
+    Test it with this demo:  <a href="/scripts/demo.ps1?message=Hello%20world!">/script/demo.ps1?message=Hello%20world!</a>
+    This feature can be used to gather data that the API doesn't expose directly.</p>
+
     <h2>Resources</h2>
     
     <h3>Version</h3>

--- a/web/APIDocs.html
+++ b/web/APIDocs.html
@@ -8,7 +8,7 @@
     <p>Anything other than the resources listed below will be looked for in the web directory and sent if it exists.</p>
     
     <p>Any .ps1 files in the web directory will be run and their output sent. They get passed a $Parameters object with keys and values from the URL string.
-    Test it with this demo:  <a href="/scripts/demo.ps1?message=Hello%20world!">/script/demo.ps1?message=Hello%20world!</a>
+    Test it with this demo:  <a href="/scripts/demo.ps1?message=Hello%20world!">/scripts/demo.ps1?message=Hello%20world!</a>
     This feature can be used to gather data that the API doesn't expose directly.</p>
 
     <h2>Resources</h2>

--- a/web/APIDocs.html
+++ b/web/APIDocs.html
@@ -8,7 +8,7 @@
     <p>Anything other than the resources listed below will be looked for in the web directory and sent if it exists.</p>
     
     <p>Any .ps1 files in the web directory will be run and their output sent. They get passed a $Parameters object with keys and values from the URL string.
-    Test it with this demo:  <a href="/scripts/demo.ps1?message=Hello%20world!">/scripts/demo.ps1?message=Hello%20world!</a>
+    Test it with this demo:  <a href="http://localhost:3999/scripts/demo.ps1?message=Hello%20world!">/scripts/demo.ps1?message=Hello%20world!</a>
     This feature can be used to gather data that the API doesn't expose directly.</p>
 
     <h2>Resources</h2>

--- a/web/scripts/demo.ps1
+++ b/web/scripts/demo.ps1
@@ -1,0 +1,4 @@
+# Try running this script as:  http://localhost:3999/scripts/demo.ps1?message=Hello%20World!
+
+param($Parameters)
+Write-Output $Parameters.message


### PR DESCRIPTION
Changes the API slightly to server files in the web directory. This will allow us to build a website around the API, showing the miner, pool, and balance information nicely formatted in a web browser.  

This can mostly replace the launcher I had previously demoed in #958, and perhaps the log viewer as well.  Since it only requires a web browser, it's already cross platform should we every support linux as well.

The website portion is a work in progress that I'm not quite ready to show off, but it's coming.

