### PR TITLE
Fix Balance message for Zpool

### DIFF
--- a/Balances/Zpool.ps1
+++ b/Balances/Zpool.ps1
@@ -7,7 +7,7 @@ $MyConfig = $Config.Pools.$Name
 $Request = [PSCustomObject]@{}
 
 if(!$MyConfig.BTC) {
-  Write-Log -Level Verbose "Pool API ($Name) has failed - no wallet address specified."
+  Write-Log -Level Verbose "Pool Balance API ($Name) has failed - no wallet address specified."
   return
 }
 
@@ -15,7 +15,7 @@ try {
     $Request = Invoke-RestMethod "http://zpool.ca/api/wallet?address=$($MyConfig.BTC)" -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
 }
 catch {
-    Write-Log -Level Warn "Pool API ($Name) has failed. "
+    Write-Log -Level Warn "Pool Balance API ($Name) has failed. "
 }
 
 if (($Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Measure-Object Name).Count -le 1) {


### PR DESCRIPTION
2018-06-03 22:43:13 VERBOSE: Pool Balance API (AHashPool) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (BlazePool) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (BlockMasters) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (HashRefinery) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (MiningPoolHub) has failed - no API key specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (Nicehash) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (PhiPhiPool) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool Balance API (ZergPool) has failed - no wallet address specified.
2018-06-03 22:43:13 VERBOSE: Pool API (Zpool) has failed - no wallet address specified.