### PR TITLE
API: Process server side includes for html files

### DIFF
--- a/API.psm1
+++ b/API.psm1
@@ -64,12 +64,6 @@
 
             # Set the proper content type, status code and data for each resource
             Switch($Path) {
-                "/" {
-                    # Serve index page
-                    $ContentType = "text/html"
-                    $Data = Get-Content($BasePath + '/APIDocs.html')
-                    break
-                }
                 "/version" {
                     $Data = $API.Version | ConvertTo-Json
                     break
@@ -144,6 +138,11 @@
                     break
                 }
                 default {
+                    # Set index page
+                    if ($Path -eq "/") {
+                        $Path = "/index.html"
+                    }
+
                     # Check if there is a file with the requested path
                     $Filename = $BasePath + $Path
                     if (Test-Path $Filename -PathType Leaf) {
@@ -155,6 +154,19 @@
                             $Data = & $File.FullName -Parameters $Parameters
                         } else {
                             $Data = Get-Content $Filename -Raw
+
+                            # Process server side includes for html files
+                            # Includes are in the traditional '<!-- #include file="/path/filename.html" -->' format used by many web servers
+                            if($File.Extension -eq ".html") {
+                                $IncludeRegex = [regex]'<!-- *#include *file="(.*)" *-->'
+                                $IncludeRegex.Matches($Data) | Foreach-Object {
+                                    $IncludeFile = $BasePath +'/' + $_.Groups[1].Value
+                                    If (Test-Path $IncludeFile -PathType Leaf) {
+                                        $IncludeData = Get-Content $IncludeFile -Raw
+                                        $Data = $Data -Replace $_.Value, $IncludeData
+                                    }
+                                }
+                            }
                         }
 
                         # Set content type based on file extension


### PR DESCRIPTION
Lets pages include another file as part of their source. Which means you
can have a file called "header.html" that has all the <head>...</head>
content like javascript and CSS files and include it in every other
pages, instead of having to change it in every file when changes are
made.

Uses the same syntax IIS and Apache usually use for including files:
`<!--#include file="/path/to/file.html" -->`