### PR TITLE
Update FireIceNvidia to version 2.4.4

### DIFF
--- a/Miners/FireiceNvidia.ps1
+++ b/Miners/FireiceNvidia.ps1
@@ -1,8 +1,8 @@
 ﻿using module ..\Include.psm1
 
 $Path = ".\Bin\CryptoNight-FireIce\xmr-stak.exe"
-$HashSHA256 = "BF7EBD6EBECF9AA84FAAF657B80BA7848ED07CD5E1F74AED2E2317B347718FF0"
-$Uri = "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.3/xmr-stak-win64.zip"
+$HashSHA256 = "F99E89588DA1A4A924ECB1BD3E7CBFDD8EA3EAD239C2506F2653481ED89433AF"
+$Uri = "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.4/xmr-stak-win64.zip"
 
 $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
 $Port = 3335


### PR DESCRIPTION
Yet Another Bugfix

This release fixes some critical bugs in the job consumption part of the miner, bring support for new coins and NVIDIA CUDA 9.2. It could be that the miner skipped a job if the pool is sending very fast new jobs.

Config files from 2.4.2/2.4.3 are compatible to this release.

Changelog:
fix job update race conditions
fix OpenBSD compile
add currency
turtlecoin
IPBC coin
masari coin
support for stellite v4 fork
extent benchmark option
fix that cli option --noAMDCache
fix possible NVIDIA Volat bug
add support for CUDA 9.2
fix broken AMD APP SDK download
