### PR TITLE
Update Cast.txt to version 1.10

### DIFF
--- a/Miners/Cast.txt
+++ b/Miners/Cast.txt
@@ -2,7 +2,7 @@
     {
         "Type":  "AMD",
         "Path":  ".\\Bin\\CryptoNight-Cast\\cast_xmr-vega.exe",
-        "HashSHA256": "ABC7BF9EA259E0BB3EF71A30BB30E3D4CBA33D6EDCCEBE4F38375DA2F3776B59",
+        "HashSHA256": "BDE75273C492C57DDCFD4AD57F5DF3BE3D34AC03C168EAD565AEBCEAF4ABA8F3",
         "Arguments":  "\"--remoteaccess --algo=1 -S $($Pools.CryptoNightV7.Host):$($Pools.CryptoNightV7.Port) -u $($Pools.CryptoNightV7.User) -p $($Pools.CryptoNightV7.Pass) --intensity=8 --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
         "HashRates":  {
                           "CryptoNightV7":  "\"$(if ($Pools.CryptoNightV7.SSL) {0}else {$Stats.Cast_CryptoNightV7_HashRate.Week})\""
@@ -14,7 +14,7 @@
     {
         "Type":  "AMD",
         "Path":  ".\\Bin\\CryptoNight-Cast\\cast_xmr-vega.exe",
-        "HashSHA256": "ABC7BF9EA259E0BB3EF71A30BB30E3D4CBA33D6EDCCEBE4F38375DA2F3776B59",
+        "HashSHA256": "BDE75273C492C57DDCFD4AD57F5DF3BE3D34AC03C168EAD565AEBCEAF4ABA8F3",
         "Arguments":  "\"--remoteaccess --algo=3 -S $($Pools.CryptoNightLite.Host):$($Pools.CryptoNightLite.Port) -u $($Pools.CryptoNightLite.User) -p $($Pools.CryptoNightLite.Pass) --intensity=8 --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
         "HashRates":  {
                           "CryptoNightLite":  "\"$(if ($Pools.CryptoNightLite.SSL) {0}else {$Stats.Cast_CryptoNightLite_HashRate.Week})\""
@@ -26,7 +26,7 @@
     {
         "Type":  "AMD",
         "Path":  ".\\Bin\\CryptoNight-Cast\\cast_xmr-vega.exe",
-        "HashSHA256": "ABC7BF9EA259E0BB3EF71A30BB30E3D4CBA33D6EDCCEBE4F38375DA2F3776B59",
+        "HashSHA256": "BDE75273C492C57DDCFD4AD57F5DF3BE3D34AC03C168EAD565AEBCEAF4ABA8F3",
         "Arguments":  "\"--remoteaccess --algo=2 -S $($Pools.CryptoNightHeavy.Host):$($Pools.CryptoNightHeavy.Port) -u $($Pools.CryptoNightHeavy.User) -p $($Pools.CryptoNightHeavy.Pass) --intensity=8 --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
         "HashRates":  {
                           "CryptoNightHeavy":  "\"$(if ($Pools.CryptoNightHeavy.SSL) {0}else {$Stats.Cast_CryptoNightHeavy_HashRate.Week})\""

--- a/Miners/Cast.txt
+++ b/Miners/Cast.txt
@@ -3,36 +3,36 @@
         "Type":  "AMD",
         "Path":  ".\\Bin\\CryptoNight-Cast\\cast_xmr-vega.exe",
         "HashSHA256": "ABC7BF9EA259E0BB3EF71A30BB30E3D4CBA33D6EDCCEBE4F38375DA2F3776B59",
-        "Arguments":  "\"--remoteaccess -S $($Pools.CryptoNightV7.Host):$($Pools.CryptoNightV7.Port) -u $($Pools.CryptoNightV7.User) -p $($Pools.CryptoNightV7.Pass) --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
+        "Arguments":  "\"--remoteaccess --algo=1 -S $($Pools.CryptoNightV7.Host):$($Pools.CryptoNightV7.Port) -u $($Pools.CryptoNightV7.User) -p $($Pools.CryptoNightV7.Pass) --intensity=8 --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
         "HashRates":  {
                           "CryptoNightV7":  "\"$(if ($Pools.CryptoNightV7.SSL) {0}else {$Stats.Cast_CryptoNightV7_HashRate.Week})\""
                       },
         "API":  "Cast",
         "Port":  "7777",
-        "URI":  "http://www.gandalph3000.com/download/cast_xmr-vega-win64_092.zip"
+        "URI":  "http://www.gandalph3000.com/download/cast_xmr-vega-win64_110.zip"
     },
     {
         "Type":  "AMD",
         "Path":  ".\\Bin\\CryptoNight-Cast\\cast_xmr-vega.exe",
         "HashSHA256": "ABC7BF9EA259E0BB3EF71A30BB30E3D4CBA33D6EDCCEBE4F38375DA2F3776B59",
-        "Arguments":  "\"--remoteaccess -S $($Pools.CryptoNightLite.Host):$($Pools.CryptoNightLite.Port) -u $($Pools.CryptoNightLite.User) -p $($Pools.CryptoNightLite.Pass) --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
+        "Arguments":  "\"--remoteaccess --algo=3 -S $($Pools.CryptoNightLite.Host):$($Pools.CryptoNightLite.Port) -u $($Pools.CryptoNightLite.User) -p $($Pools.CryptoNightLite.Pass) --intensity=8 --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
         "HashRates":  {
                           "CryptoNightLite":  "\"$(if ($Pools.CryptoNightLite.SSL) {0}else {$Stats.Cast_CryptoNightLite_HashRate.Week})\""
                       },
         "API":  "Cast",
         "Port":  "7777",
-        "URI":  "http://www.gandalph3000.com/download/cast_xmr-vega-win64_092.zip"
+        "URI":  "http://www.gandalph3000.com/download/cast_xmr-vega-win64_110.zip"
     },
     {
         "Type":  "AMD",
         "Path":  ".\\Bin\\CryptoNight-Cast\\cast_xmr-vega.exe",
         "HashSHA256": "ABC7BF9EA259E0BB3EF71A30BB30E3D4CBA33D6EDCCEBE4F38375DA2F3776B59",
-        "Arguments":  "\"--remoteaccess -S $($Pools.CryptoNightHeavy.Host):$($Pools.CryptoNightHeavy.Port) -u $($Pools.CryptoNightHeavy.User) -p $($Pools.CryptoNightHeavy.Pass) --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
+        "Arguments":  "\"--remoteaccess --algo=2 -S $($Pools.CryptoNightHeavy.Host):$($Pools.CryptoNightHeavy.Port) -u $($Pools.CryptoNightHeavy.User) -p $($Pools.CryptoNightHeavy.Pass) --intensity=8 --forcecompute --fastjobswitch$($DeviceID = 0; $DeviceIDs = @();([OpenCl.Platform]::GetPlatformIDs() | ForEach-Object {[OpenCl.Device]::GetDeviceIDs($_, [OpenCl.DeviceType]::All)} | Where {$_.Type -eq 'GPU' -and $_.Vendor -match 'Advanced Micro Devices, Inc.'} | ForEach-Object {$DeviceIDs += $DeviceID; $DeviceID++});if($DeviceIDs){' -G';$($DeviceIDs -join ',')})\"",
         "HashRates":  {
                           "CryptoNightHeavy":  "\"$(if ($Pools.CryptoNightHeavy.SSL) {0}else {$Stats.Cast_CryptoNightHeavy_HashRate.Week})\""
                       },
         "API":  "Cast",
         "Port":  "7777",
-        "URI":  "http://www.gandalph3000.com/download/cast_xmr-vega-win64_092.zip"
+        "URI":  "http://www.gandalph3000.com/download/cast_xmr-vega-win64_110.zip"
     }
 ]


### PR DESCRIPTION
Version 1.10 is much better for AMD Vega cards running on Adrenaline driver 18.4.1. It has replaced the --maxmem input with --intensity=x, allowing users to adjust the intensity based on their card. It also has a tool to allow users to turn on compute mode for RX 400/500 series cards, large page sizes for Vega Cards, and toggle HBCC memory. This must be done manually. You must also specify the algorithm with --algo=x.