### PR TITLE
Fix Type_PlatformId_Index

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -527,7 +527,7 @@ function Get-Device {
                     Index = [Int]$Index
                     PlatformId = [Int]$PlatformId
                     PlatformId_Index = [Int]$PlatformId_Index.($PlatformId)
-                    Type_PlatformId_Index = [Int]$Type_PlatformId_Index.($Device_OpenCL.Type).($PlatformId)
+                    Type_PlatformId_Index = [Int]$Type_PlatformId_Index.($Device_OpenCL.Type)."$($PlatformId)"
                     Vendor = [String]$Device_OpenCL.Vendor
                     Vendor_Index = [Int]$Vendor_Index.($Device_OpenCL.Vendor)
                     Type_Vendor_Index = [Int]$Type_Vendor_Index.($Device_OpenCL.Type).($Device_OpenCL.Vendor)
@@ -550,7 +550,7 @@ function Get-Device {
 
                 $Index++
                 $PlatformId_Index.($PlatformId)++
-                $Type_PlatformId_Index.($Device_OpenCL.Type).($PlatformId)++
+                $Type_PlatformId_Index.($Device_OpenCL.Type)."$($PlatformId)"++
                 $Vendor_Index.($Device_OpenCL.Vendor)++
                 $Type_Vendor_Index.($Device_OpenCL.Type).($Device_OpenCL.Vendor)++
                 $Type_Index.($Device_OpenCL.Type)++

--- a/Include.psm1
+++ b/Include.psm1
@@ -526,13 +526,13 @@ function Get-Device {
                 $Device = [PSCustomObject]@{
                     Index = [Int]$Index
                     PlatformId = [Int]$PlatformId
-                    PlatformId_Index = [Int]$PlatformId_Index.($PlatformId)
-                    Type_PlatformId_Index = [Int]$Type_PlatformId_Index.($Device_OpenCL.Type)."$($PlatformId)"
+                    PlatformId_Index = [Int]$PlatformId_Index."$($PlatformId)"
+                    Type_PlatformId_Index = [Int]$Type_PlatformId_Index."$($Device_OpenCL.Type)"."$($PlatformId)"
                     Vendor = [String]$Device_OpenCL.Vendor
-                    Vendor_Index = [Int]$Vendor_Index.($Device_OpenCL.Vendor)
-                    Type_Vendor_Index = [Int]$Type_Vendor_Index.($Device_OpenCL.Type).($Device_OpenCL.Vendor)
+                    Vendor_Index = [Int]$Vendor_Index."$($Device_OpenCL.Vendor)"
+                    Type_Vendor_Index = [Int]$Type_Vendor_Index."$($Device_OpenCL.Type)"."$($Device_OpenCL.Vendor)"
                     Type = [String]$Device_OpenCL.Type
-                    Type_Index = [Int]$Type_Index.($Device_OpenCL.Type)
+                    Type_Index = [Int]$Type_Index."$($Device_OpenCL.Type)"
                     OpenCL = $Device_OpenCL
                     Model = [String]$Device_OpenCL.Name
                 }
@@ -541,19 +541,19 @@ function Get-Device {
                     $Device | Add-Member Name ("{0}#{1:d2}" -f $Device.Type, $Device.Type_Index).ToUpper() -PassThru
                 }
 
-                if (-not $Type_PlatformId_Index.($Device_OpenCL.Type)) {
-                    $Type_PlatformId_Index.($Device_OpenCL.Type) = @{}
+                if (-not $Type_PlatformId_Index."$($Device_OpenCL.Type)") {
+                    $Type_PlatformId_Index."$($Device_OpenCL.Type)" = @{}
                 }
-                if (-not $Type_Vendor_Index.($Device_OpenCL.Type)) {
-                    $Type_Vendor_Index.($Device_OpenCL.Type) = @{}
+                if (-not $Type_Vendor_Index."$($Device_OpenCL.Type)") {
+                    $Type_Vendor_Index."$($Device_OpenCL.Type)" = @{}
                 }
 
                 $Index++
-                $PlatformId_Index.($PlatformId)++
-                $Type_PlatformId_Index.($Device_OpenCL.Type)."$($PlatformId)"++
-                $Vendor_Index.($Device_OpenCL.Vendor)++
-                $Type_Vendor_Index.($Device_OpenCL.Type).($Device_OpenCL.Vendor)++
-                $Type_Index.($Device_OpenCL.Type)++
+                $PlatformId_Index."$($PlatformId)"++
+                $Type_PlatformId_Index."$($Device_OpenCL.Type)"."$($PlatformId)"++
+                $Vendor_Index."$($Device_OpenCL.Vendor)"++
+                $Type_Vendor_Index."$($Device_OpenCL.Type)"."$($Device_OpenCL.Vendor)"++
+                $Type_Index."$($Device_OpenCL.Type)"++
             }
 
             $PlatformId++


### PR DESCRIPTION
So this is a weird enough bug that I'm half convinced it's a bug in powershell, not our code.

This works fine and increments as expected
```
PS C:\> $platform = 0
PS C:\> $index = @{}
PS C:\> $index.($platform)++
PS C:\> $index.($platform)
1
PS C:\> $index.($platform)++
PS C:\> $index.($platform)
2
```

This (which is used for Type_PlatformId_Index) does not:
```
PS C:\> $type = "Gpu"
PS C:\> $platform = 0
PS C:\> $index = @{}
PS C:\> $index.($type) = @{}
PS C:\> $index.($type).($platform)++
PS C:\> $index.Gpu.0
1
PS C:\> $index.($type).($platform)++
PS C:\> $index.Gpu.0
1
PS C:\> $index.($type).0 = 5
PS C:\> $index.Gpu.0
5
PS C:\> $index.($type).($platform)++
PS C:\> $index.Gpu.0
1
```

It seems that **only when in a nested hashtable**, using a numeric key breaks things.  That's why Type_PlatformId_Index is always 0, no matter how many cards of the same type and platform you have.

Oh, and for bonus points, it only SOMETIMES seems to do that.  I can't seem to figure out what other conditions make it happen, because running that exact same code in another powershell window gives me correct results with it incrementing as expected.  But I swear that the lines above are a direct copy/paste from a powershell window.  I can't duplicate it again.  But it did happen.  WTF?

Using numeric hashtable keys doesn't work all that great anyways since you can't do things like ConvertTo-Json if there are numeric keys.

I just wrapped the ($Platform) part in quotes so it's treated as a string.  Now it increments properly.