### PR TITLE
Detect CPUs through CIM instead of OpenCL

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -582,19 +582,16 @@ function Get-Device {
     [array]$Devices = $Devices | Where-Object {$_.Type -ne "Cpu"}
 
     $CPUIndex = 0
-    Get-CimInstance -ClassName Win32_Processor | Foreach-Object {
-        # Vendor, type and platform are all the same for all CPUs, so there is no need to actually track the extra indexes.  Include them only for compatibility.
+    Get-CimInstance -ClassName CIM_Processor | Foreach-Object {
+        # Vendor and type the same for all CPUs, so there is no need to actually track the extra indexes.  Include them only for compatibility.
         $CPUInfo = $_ | ConvertTo-Json | ConvertFrom-Json
         $Device = [PSCustomObject]@{
             Index = [Int]$Index
-            PlatformId = [Int]$PlatformId
-            PlatformId_Index = $CPUIndex
-            Type_PlatformId_Index = $CPUIndex
             Vendor = $CPUInfo.Manufacturer
             Type_Vendor_Index = $CPUIndex
             Type = "Cpu"
             Type_Index = $CPUIndex
-            Info = $CPUInfo
+            CIM = $CPUInfo
             Model = $CPUInfo.Name
         }
 


### PR DESCRIPTION
This generates the CPU devices using WMI/CIM instead of OpenCL.  WMI is going to have the most accurate information available about the processors, and doesn't rely on any drivers besides what's built into windows, so it makes sense to pull the information from there.

Tested on systems with and without CPU OpenCL drivers, and on multi processor systems where it properly generates 2-4 devices, one for each physical CPU.

I intend to try to expand on this in a future PR to include the supported instruction sets in the Info property, if I can find a way of doing it that isn't ugly, but this is enough on its own to get CPU mining working properly again.

Fixes #1866 
Relates to #1857 

Edit:  Added caching of the devices.  They shouldn't be changing while the script is running, but just in case we add some data that does change (like temperature or utilization) I added a -refresh switch to update the cached devices.  Needed because CIM is fairly slow, and Get-Device gets called for each and every miner to update the DeviceName list for backwards compatibility.