### PR TITLE
Fix ZergPool divisor problem

### DIFF
--- a/Pools/ZergPool.ps1
+++ b/Pools/ZergPool.ps1
@@ -76,6 +76,10 @@ $ZergPool_MiningCurrencies | Where-Object {$ZergPoolCoins_Request.$_.hashrate -g
     $ZergPool_Currency = $_
 
     $Divisor = 1000000000 * [Double]$ZergPool_Request.$ZergPool_Algorithm.mbtc_mh_factor
+    if ($Divisor -eq 0) {
+        Write-Log -Level Info "Unable to determine divisor for $ZergPool_Coin using $ZergPool_Algorithm_Norm algorithm"
+        return
+    }
 
     $Stat = Set-Stat -Name "$($Name)_$($_)_Profit" -Value ([Double]$ZergPoolCoins_Request.$_.estimate / $Divisor) -Duration $StatSpan -ChangeDetection $true
 


### PR DESCRIPTION
ZergPool is the only one this affects, because it gets the divisors from a separate place than the coin data. 
 There is at least one coin where the algorithm it uses isn't in there, so the divisor ends up set to 0.

That causes an error about NaN in Set-Stat (which actually does already handle it properly, refusing to run).

This change will skip over coins where the divisor can't be detected so that it doesn't cause any errors.