### PR TITLE
Show device model alongside it's name

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -619,7 +619,7 @@ while ($true) {
     $API.MinersNeedingBenchmark = $MinersNeedingBenchmark
 
     #Display mining information
-    $Miners | Where-Object {$_.Profit -ge 1E-5 -or $_.Profit -eq $null} | Sort-Object DeviceName, @{Expression = "Profit_Bias"; Descending = $True} | Format-Table -GroupBy @{Name = "Device"; Expression = "DeviceName"} (
+    $Miners | Where-Object {$_.Profit -ge 1E-5 -or $_.Profit -eq $null} | Sort-Object DeviceName, @{Expression = "Profit_Bias"; Descending = $True} | Format-Table -GroupBy @{Name = "Device"; Expression = {"$($_.DeviceName) - $((Get-Device $_.DeviceName).Model -join ', ')"}} (
         @{Label = "Miner[Fee]"; Expression = {"$($_.Name)$(($_.Fees.PSObject.Properties.Value | ForEach-Object {"[{0:P2}]" -f [Double]$_}) -join '')"}}, 
         @{Label = "Algorithm"; Expression = {$_.HashRates.PSObject.Properties.Name}}, 
         @{Label = "Speed"; Expression = {$_.HashRates.PSObject.Properties.Value | ForEach-Object {if ($_ -ne $null) {"$($_ | ConvertTo-Hash)/s"}else {"Benchmarking"}}}; Align = 'right'}, 


### PR DESCRIPTION
Instead of headers being
```
Device: GPU#01
Device: GPU#00 GPU#01
Device: CPU#00
```

This gives:
```
Device: GPU#01 - GeForce GTX 1070
Device: GPU#00 GPU#01 - GeForce GTX 1080, GeForce GTX 1070
Device: CPU#00 - Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
```

Makes it easier to see which card is which.