### PR TITLE
Arrays should always be arrays

### DIFF
--- a/MinersLegacy/ClaymoreEthash.ps1
+++ b/MinersLegacy/ClaymoreEthash.ps1
@@ -51,7 +51,7 @@ $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty
 $Devices = $Devices | Where-Object Type -EQ "GPU"
 
 $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
-    $Device = $Devices | Where-Object Vendor -EQ $_.Vendor | Where-Object Model -EQ $_.Model
+    $Device = @($Devices | Where-Object Vendor -EQ $_.Vendor | Where-Object Model -EQ $_.Model)
     $Miner_Port = $Port -f ($Device | Select-Object -First 1 -ExpandProperty Index)
 
     switch ($_.Vendor) {
@@ -66,9 +66,9 @@ $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
 
         Switch ($MainAlgorithm_Norm) {
             # default is all devices, ethash has a 4GB minimum memory limit
-            "Ethash" {$Miner_Device = $Device | Where-Object {$_.OpenCL.GlobalMemsize -ge 4000000000}}
-            "Ethash3gb" {$Miner_Device = $Device | Where-Object {$_.OpenCL.GlobalMemsize -ge 3000000000}}
-            default {$Miner_Device = $Device}
+            "Ethash" {$Miner_Device = @($Device | Where-Object {$_.OpenCL.GlobalMemsize -ge 4000000000})}
+            "Ethash3gb" {$Miner_Device = @($Device | Where-Object {$_.OpenCL.GlobalMemsize -ge 3000000000})}
+            default {$Miner_Device = @($Device)}
         }
 
         if ($Arguments_Platform -and $Miner_Device) {

--- a/MinersLegacy/ClaymoreEthash.ps1
+++ b/MinersLegacy/ClaymoreEthash.ps1
@@ -48,7 +48,7 @@ $Commands = [PSCustomObject[]]@(
 )
 
 $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName)"
-$Devices = $Devices | Where-Object Type -EQ "GPU"
+$Devices = @($Devices | Where-Object Type -EQ "GPU")
 
 $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
     $Device = @($Devices | Where-Object Vendor -EQ $_.Vendor | Where-Object Model -EQ $_.Model)

--- a/MinersLegacy/Excavator.ps1
+++ b/MinersLegacy/Excavator.ps1
@@ -43,7 +43,7 @@ $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty Ba
 $Devices = $Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "NVIDIA Corporation"
 
 $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
-    $Miner_Device = $Devices | Where-Object Vendor -EQ $_.Vendor | Where-Object Model -EQ $_.Model
+    $Miner_Device = @($Devices | Where-Object Model -EQ $_.Model)
     $Miner_Port = $Port -f ($Miner_Device | Select-Object -First 1 -ExpandProperty Index)
 
     $Commands | ForEach-Object {

--- a/MinersLegacy/Excavator.ps1
+++ b/MinersLegacy/Excavator.ps1
@@ -40,7 +40,7 @@ $Commands = [PSCustomObject[]]@(
 )
 
 $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
-$Devices = $Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "NVIDIA Corporation"
+$Devices = @($Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "NVIDIA Corporation")
 
 $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
     $Miner_Device = @($Devices | Where-Object Model -EQ $_.Model)

--- a/MinersLegacy/Excavator.ps1
+++ b/MinersLegacy/Excavator.ps1
@@ -43,7 +43,7 @@ $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty Ba
 $Devices = @($Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "NVIDIA Corporation")
 
 $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
-    $Miner_Device = @($Devices | Where-Object Model -EQ $_.Model)
+    $Miner_Device = @($Devices | Where-Object Vendor -EQ $_.Vendor | Where-Object Model -EQ $_.Model)
     $Miner_Port = $Port -f ($Miner_Device | Select-Object -First 1 -ExpandProperty Index)
 
     $Commands | ForEach-Object {


### PR DESCRIPTION
Objects that can be arrays should always be arrays.
Like this we can reliably use .count and other methods.