### PR TITLE
ExtendInterval as miner property

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -650,6 +650,7 @@ class Miner {
     $Pool
     hidden [Array]$Data = @()
     $ShowMinerWindow
+    $ExtendInterval
 
     [String[]]GetProcessNames() {
         return @(([IO.FileInfo]($this.Path | Split-Path -Leaf -ErrorAction Ignore)).BaseName)

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -18,10 +18,6 @@ param(
     [Parameter(Mandatory = $false)]
     [Int]$Interval = 60, #seconds before reading hash rate from miners
     [Parameter(Mandatory = $false)]
-    [Array]$ExtendIntervalAlgorithm = @("X16R", "X16S"), #Extend interval duration by a factor of 10x $Interval for these algorithms
-    [Parameter(Mandatory = $false)]
-    [Array]$ExtendIntervalMinerName = @("PalginNvidia"), #Extend interval duration by a factor of 10x $Interval for these miners
-    [Parameter(Mandatory = $false)]
     [Alias("Location")]
     [String]$Region = "europe", #europe/us/asia
     [Parameter(Mandatory = $false)]
@@ -698,14 +694,20 @@ while ($true) {
     Get-Job -State Completed | Remove-Job
     [GC]::Collect()
 
-    #When benchmarking miners/algorithm in ExtendInterval... add 10x $Config.Interval to $StatEnd, extend StatSpan, extend watchdog times
-    $BenchmarkingMiners = $RunningMiners | Where-Object {$_.Speed -eq $null}
-    if ($BenchmarkingMiners | Where-Object {$Config.ExtendIntervalMinerName -icontains $_.Name -or ($_.Algorithm | Where-Object {$Config.ExtendIntervalAlgorithm -icontains $_})}) {
-        $StatEnd = $StatEnd.AddSeconds($Config.Interval * 10)
+    #Benchmarking miners/algorithm with ExtendInterval
+    $Multiplier = 0
+    $RunningMiners | Where-Object {$_.Speed -eq $null} | ForEach-Object {
+        if ($_.ExtendInterval -ge $Multiplier) {$Multiplier = $_.ExtendInterval}
+    }
+    
+    #Multiply $Config.Interval and add it to $StatEnd, extend StatSpan, extend watchdog times
+    if ($Multiplier -gt 0) {
+        if ($Multiplier -gt 10) {$Multiplier = 10}
+        $StatEnd = $StatEnd.AddSeconds($Config.Interval * $Multiplier)
         $StatSpan = New-TimeSpan $StatStart $StatEnd
         $WatchdogInterval = ($WatchdogInterval / $Strikes * ($Strikes - 1)) + $StatSpan.TotalSeconds
         $WatchdogReset = ($WatchdogReset / ($Strikes * $Strikes * $Strikes) * (($Strikes * $Strikes * $Strikes) - 1)) + $StatSpan.TotalSeconds
-        Write-Log "Benchmarking watchdog sensitive algorithm or miner. Increasing interval time temporarily to 10x interval ($($Config.Interval * 10) seconds). "
+        Write-Log "Benchmarking watchdog sensitive algorithm or miner. Increasing interval time temporarily to $($Multiplier)x interval ($($Config.Interval * $($Multiplier)) seconds). "
     }
 
     #Do nothing for a few seconds as to not overload the APIs and display miner download status
@@ -740,7 +742,7 @@ while ($true) {
                 if ($Miner.New -and (-not $Miner_Speed)) {$Miner_Speed = $Miner.GetHashRate($_, ($Interval * $Miner.Benchmarked), ($Miner.Benchmarked -lt $Strikes))}
 
                 if ((-not $Miner.New) -or $Miner_Speed -or $Miner.Benchmarked -ge ($Strikes * $Strikes) -or $Miner.GetActivateCount() -ge $Strikes) {
-                    $Stat = Set-Stat -Name "$($Miner.Name)_$($_)_HashRate" -Value $Miner_Speed -Duration $StatSpan -FaultDetection ($Config.ExtendIntervalAlgorithm -inotcontains $_ -and $Config.ExtendIntervalMinerName -inotcontains $Miner.Name)
+                    $Stat = Set-Stat -Name "$($Miner.Name)_$($_)_HashRate" -Value $Miner_Speed -Duration $StatSpan -FaultDetection (-not $_.ExtendInterval)
                 }
 
                 #Update watchdog timer

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -736,10 +736,10 @@ while ($true) {
 
         if ($Miner.GetStatus() -eq "Running" -or $Miner.New) {
             $Miner.Algorithm | ForEach-Object {
-                $Miner_Speed = $Miner.GetHashRate($_, $Interval, $Miner.New)
+                $Miner_Speed = $Miner.GetHashRate($_, $Config.Interval, $Miner.New)
                 $Miner.Speed_Live += [Double]$Miner_Speed
 
-                if ($Miner.New -and (-not $Miner_Speed)) {$Miner_Speed = $Miner.GetHashRate($_, ($Interval * $Miner.Benchmarked), ($Miner.Benchmarked -lt $Strikes))}
+                if ($Miner.New -and (-not $Miner_Speed)) {$Miner_Speed = $Miner.GetHashRate($_, ($Config.Interval * $Miner.Benchmarked), ($Miner.Benchmarked -lt $Strikes))}
 
                 if ((-not $Miner.New) -or $Miner_Speed -or $Miner.Benchmarked -ge ($Strikes * $Strikes) -or $Miner.GetActivateCount() -ge $Strikes) {
                     $Stat = Set-Stat -Name "$($Miner.Name)_$($_)_HashRate" -Value $Miner_Speed -Duration $StatSpan -FaultDetection (-not $_.ExtendInterval)


### PR DESCRIPTION
Due to their nature some algorithms, e.g. 'X16R', will always trigger watchdog on normal interval duration.

This PR adds support for the miner property 'ExtendInterval = [Int]n'.

When benchmarking MPM will extend the interval timer duration n times.
A message indication the extended benchmark timer will be written to the log.

@aaronsace: as initially requested in https://github.com/MultiPoolMiner/MultiPoolMiner/pull/1786

I will update the affected miner file one by one once this PR has been commited.