### PR TITLE
Update BMiner

### DIFF
--- a/MinersLegacy/BMiner.txt
+++ b/MinersLegacy/BMiner.txt
@@ -1,12 +1,12 @@
 ﻿{
     "Type":  "NVIDIA",
     "Path":  ".\\Bin\\NVIDIA-BMiner\\BMiner.exe",
-    "HashSHA256": "22E6C2797D6024D5E8AF28EC9D2BDAA6AB5C076DF729B96CC0CC9B2C348CDA51",
+    "HashSHA256": "94F40A763FC4182663A5F3E1885EE4E3EDF1E1DBB69F8CFC170109DB7320081B",
     "Arguments":  "\"-api 127.0.0.1:1880 -uri $(if ($Pools.Equihash.SSL) {'stratum+ssl'}else {'stratum'})://$([System.Web.HttpUtility]::UrlEncode($Pools.Equihash.User)):$([System.Web.HttpUtility]::UrlEncode($Pools.Equihash.Pass))@$($Pools.Equihash.Host):$($Pools.Equihash.Port) -nofee -watchdog=false\"",
     "HashRates":  {
                       "Equihash":  "\"$($Stats.Bminer_Equihash_HashRate.Week)\""
                   },
     "API":  "Bminer",
     "Port":  "1880",
-    "URI":  "https://www.bminercontent.com/releases/bminer-v6.1.0-7ea8bbe-amd64.zip"
+    "URI":  "https://www.bminercontent.com/releases/bminer-lite-v9.0.0-199ca8c-amd64.zip"
 }


### PR DESCRIPTION
Update BMiner to version 9.0.0

This version also supports dual mining of ETH+Decred, but would need to be rewritten to support that.