### PR TITLE
Update Algorithms.txt: Fix Phi2

### DIFF
--- a/Algorithms.txt
+++ b/Algorithms.txt
@@ -104,7 +104,7 @@
     "pascal":  "Pascal",
     "pentablake":  "PentaBlake",
     "phi":  "PHI",
-    "phi2":  "PHI",
+    "phi2":  "PHI2",
     "phi1612":  "PHI",
     "phoenixcoin":  "NeoScrypt",
     "pluck":  "Pluck",


### PR DESCRIPTION
Fix PHI2 algorithm.
Apparently old Phi is Phi1612, Phi2 is new and will be used for LuxCoin after hardfork.
https://www.reddit.com/r/LUXCoin/comments/8t1d7e/luxcore_community_update_v5_mercury_release/
https://github.com/216k155/lux

Currently there is no pool mining LuxCoin.