### PR TITLE
Fix pool Get-Balance on unconfigured pools

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -11,7 +11,7 @@ function Get-Balance {
         $Rates = [PSCustomObject]@{BTC = [Double]1}
     }
 
-    $Balances = @(Get-ChildItem "Balances" -File | Where-Object {$Config.Pools.$($_.BaseName) -and ($Config.ExcludePoolName -inotcontains $_.BaseName) -or $Config.ShowPoolBalancesExcludedPools} | ForEach-Object {
+    $Balances = @(Get-ChildItem "Balances" -File | Where-Object {$Config.Pools.$($_.BaseName) -and ($Config.ExcludePoolName -inotcontains $_.BaseName -or $Config.ShowPoolBalancesExcludedPools)} | ForEach-Object {
             Get-ChildItemContent "Balances\$($_.Name)" -Parameters @{Config = $Config}
         } | Foreach-Object {$_.Content | Add-Member Name $_.Name -PassThru})
 


### PR DESCRIPTION
Fixes an issue where Get-Balance tries to read the balance from a pool with no wallet information and 'ShowPoolBalancesExcludedPools' is set to $true.

Cause: MPM only populates $Config.Wallet only for pools where a pool file exists (Lines 176 - 186). 
If ShowPoolBalancesExcludedPools is true then Get-Balance attempts to read the balance of all pools (and not just the configured ones).
The missing wallet information will cause Get-Balance (Balance\[PoolName].ps1) to throw an error 'Pool Balance API ($Name) has failed - no wallet address specified.'



