### PR TITLE
Fix MinerNeedingBenchmarks counter

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -599,7 +599,7 @@ while ($true) {
 
     Clear-Host
     #Get miners needing benchmarking
-    $MinersNeedingBenchmark = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -eq $null})
+    $MinersNeedingBenchmark = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -contains $null} | Select-Object Name -Unique)
     $API.MinersNeedingBenchmark = $MinersNeedingBenchmark
 
     #Display mining information

--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -599,7 +599,7 @@ while ($true) {
 
     Clear-Host
     #Get miners needing benchmarking
-    $MinersNeedingBenchmark = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -contains $null} | Select-Object Name -Unique)
+    $MinersNeedingBenchmark = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -contains $null})
     $API.MinersNeedingBenchmark = $MinersNeedingBenchmark
 
     #Display mining information


### PR DESCRIPTION
Fixes counting dual-algo miners. 
These were not listed as needing benchmark if one algo had been benchmarked, but the second one had not.

Steps to reproduce:
Delete ONE benchmark file of a dual miner. -> MPM will not recognize it as needing benchmark.