### PR TITLE
Force API calls to return arrays, add /currentprofit

### DIFF
--- a/API.psm1
+++ b/API.psm1
@@ -69,31 +69,31 @@
                     break
                 }
                 "/activeminers" {
-                    $Data = ConvertTo-Json @($API.ActiveMiners)
+                    $Data = ConvertTo-Json @($API.ActiveMiners | Select-Object)
                     break
                 }
                 "/runningminers" {
-                    $Data = ConvertTo-Json @($API.RunningMiners)
+                    $Data = ConvertTo-Json @($API.RunningMiners | Select-Object)
                     Break
                 }
                 "/failedminers" {
-                    $Data = ConvertTo-Json @($API.FailedMiners)
+                    $Data = ConvertTo-Json @($API.FailedMiners | Select-Object)
                     Break
                 }
                 "/minersneedingbenchmark" {
-                    $Data = ConvertTo-Json @($API.MinersNeedingBenchmark)
+                    $Data = ConvertTo-Json @($API.MinersNeedingBenchmark | Select-Object)
                     Break
                 }
                 "/pools" {
-                    $Data = ConvertTo-Json @($API.Pools)
+                    $Data = ConvertTo-Json @($API.Pools | Select-Object)
                     Break
                 }
                 "/newpools" {
-                    $Data = ConvertTo-Json @($API.NewPools)
+                    $Data = ConvertTo-Json @($API.NewPools | Select-Object)
                     Break
                 }
                 "/allpools" {
-                    $Data = ConvertTo-Json @($API.AllPools)
+                    $Data = ConvertTo-Json @($API.AllPools | Select-Object)
                     Break
                 }
                 "/algorithms" {
@@ -101,11 +101,11 @@
                     Break
                 }
                 "/miners" {
-                    $Data = ConvertTo-Json @($API.Miners)
+                    $Data = ConvertTo-Json @($API.Miners | Select-Object)
                     Break
                 }
                 "/fastestminers" {
-                    $Data = ConvertTo-Json @($API.FastestMiners)
+                    $Data = ConvertTo-Json @($API.FastestMiners | Select-Object)
                     Break
                 }
                 "/config" {
@@ -117,19 +117,19 @@
                     Break
                 }
                 "/devices" {
-                    $Data = ConvertTo-Json @($API.Devices)
+                    $Data = ConvertTo-Json @($API.Devices | Select-Object)
                     Break
                 }
                 "/stats" {
-                    $Data = ConvertTo-Json @($API.Stats)
+                    $Data = ConvertTo-Json @($API.Stats | Select-Object)
                     Break
                 }
                 "/watchdogtimers" {
-                    $Data = ConvertTo-Json @($API.WatchdogTimers)
+                    $Data = ConvertTo-Json @($API.WatchdogTimers | Select-Object)
                     Break
                 }
                 "/balances" {
-                    $Data = ConvertTo-Json @($API.Balances)
+                    $Data = ConvertTo-Json @($API.Balances | Select-Object)
                     Break
                 }
                 "/currentprofit" {

--- a/API.psm1
+++ b/API.psm1
@@ -69,43 +69,43 @@
                     break
                 }
                 "/activeminers" {
-                    $Data = $API.ActiveMiners | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.ActiveMiners)
                     break
                 }
                 "/runningminers" {
-                    $Data = $API.RunningMiners | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.RunningMiners)
                     Break
                 }
                 "/failedminers" {
-                    $Data = $API.FailedMiners | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.FailedMiners)
                     Break
                 }
                 "/minersneedingbenchmark" {
-                    $Data = $API.MinersNeedingBenchmark | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.MinersNeedingBenchmark)
                     Break
                 }
                 "/pools" {
-                    $Data = $API.Pools | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.Pools)
                     Break
                 }
                 "/newpools" {
-                    $Data = $API.NewPools | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.NewPools)
                     Break
                 }
                 "/allpools" {
-                    $Data = $API.AllPools | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.AllPools)
                     Break
                 }
                 "/algorithms" {
-                    $Data = ($API.AllPools.Algorithm | Sort-Object -Unique) | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.AllPools.Algorithm | Sort-Object -Unique)
                     Break
                 }
                 "/miners" {
-                    $Data = $API.Miners | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.Miners)
                     Break
                 }
                 "/fastestminers" {
-                    $Data = $API.FastestMiners | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.FastestMiners)
                     Break
                 }
                 "/config" {
@@ -117,19 +117,23 @@
                     Break
                 }
                 "/devices" {
-                    $Data = $API.Devices | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.Devices)
                     Break
                 }
                 "/stats" {
-                    $Data = $API.Stats | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.Stats)
                     Break
                 }
                 "/watchdogtimers" {
-                    $Data = $API.WatchdogTimers | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.WatchdogTimers)
                     Break
                 }
                 "/balances" {
-                    $Data = $API.Balances | ConvertTo-Json
+                    $Data = ConvertTo-Json @($API.Balances)
+                    Break
+                }
+                "/currentprofit" {
+                    $Data = ($API.RunningMiners | Measure-Object -Sum -Property Profit).Sum | ConvertTo-Json
                     Break
                 }
                 "/stop" {


### PR DESCRIPTION
Forces many of the API calls to return arrays even if they are single items - makes it a lot easier to process in any application that calls them.

Also adds a /currentprofit call to return the total profit of the running miners.