### PR TITLE
Pool files: change Info -> CoinName

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -623,7 +623,7 @@ while ($true) {
         @{Label = "$($Config.Currency | Select-Object -Index 0)/Day"; Expression = {if ($_.Profit) {ConvertTo-LocalCurrency $($_.Profit) $($Rates.$($Config.Currency | Select-Object -Index 0)) -Offset 2} else {"Unknown"}}; Align = "right"}, 
         @{Label = "Accuracy"; Expression = {$_.Pools.PSObject.Properties.Value | ForEach-Object {"{0:P0}" -f [Double](1 - $_.MarginOfError)}}; Align = 'right'}, 
         @{Label = "$($Config.Currency | Select-Object -Index 0)/GH/Day"; Expression = {$_.Pools.PSObject.Properties.Value | ForEach-Object {"$(ConvertTo-LocalCurrency $($_.Price * 1000000000) $($Rates.$($Config.Currency | Select-Object -Index 0)) -Offset 2)"}}; Align = "right"}, 
-        @{Label = "Pool[Fee]"; Expression = {$_.Pools.PSObject.Properties.Value | ForEach-Object {if ($_.Info) {"$($_.Name)-$($_.Info)$("[{0:P2}]" -f [Double]$_.Fee)"}else {"$($_.Name)$("[{0:P2}]" -f [Double]$_.Fee)"}}}}
+        @{Label = "Pool[Fee]"; Expression = {$_.Pools.PSObject.Properties.Value | ForEach-Object {if ($_.CoinName) {"$($_.Name)-$($_.CoinName)$("[{0:P2}]" -f [Double]$_.Fee)"}else {"$($_.Name)$("[{0:P2}]" -f [Double]$_.Fee)"}}}}
     ) | Out-Host
 
     #Display benchmarking progres

--- a/Pools/AHashPool.ps1
+++ b/Pools/AHashPool.ps1
@@ -47,7 +47,7 @@ $AHashPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | S
         $AHashPool_Currencies | ForEach-Object {
             [PSCustomObject]@{
                 Algorithm     = $AHashPool_Algorithm_Norm
-                Info          = $AHashPool_Coin
+                CoinName      = $AHashPool_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/BlazePool.ps1
+++ b/Pools/BlazePool.ps1
@@ -47,7 +47,7 @@ $BlazePool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | S
         $BlazePool_Currencies | Where-Object {Get-Variable $_ -ValueOnly} | ForEach-Object {
             [PSCustomObject]@{
                 Algorithm     = $BlazePool_Algorithm_Norm
-                Info          = $BlazePool_Coin
+                CoinName      = $BlazePool_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/BlockMasters.ps1
+++ b/Pools/BlockMasters.ps1
@@ -48,7 +48,7 @@ $BlockMasters_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore 
         $BlockMasters_Currencies | ForEach-Object {
             [PSCustomObject]@{
                 Algorithm     = $BlockMasters_Algorithm_Norm
-                Info          = $BlockMasters_Coin
+                CoinName      = $BlockMasters_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/Hashrefinery.ps1
+++ b/Pools/Hashrefinery.ps1
@@ -48,7 +48,7 @@ $HashRefinery_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore 
         $HashRefinery_Currencies | ForEach-Object {
             [PSCustomObject]@{
                 Algorithm     = $HashRefinery_Algorithm_Norm
-                Info          = $HashRefinery_Coin
+                CoinName      = $HashRefinery_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/MiningPoolHub.ps1
+++ b/Pools/MiningPoolHub.ps1
@@ -47,7 +47,7 @@ $MiningPoolHub_Request.return | ForEach-Object {
         if ($User) {
             [PSCustomObject]@{
                 Algorithm     = $MiningPoolHub_Algorithm_Norm
-                Info          = $MiningPoolHub_Coin
+                CoinName      = $MiningPoolHub_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation
@@ -64,7 +64,7 @@ $MiningPoolHub_Request.return | ForEach-Object {
             if ($MiningPoolHub_Algorithm_Norm -eq "CryptonightV7" -or $MiningPoolHub_Algorithm_Norm -eq "Equihash") {
                 [PSCustomObject]@{
                     Algorithm     = $MiningPoolHub_Algorithm_Norm
-                    Info          = $MiningPoolHub_Coin
+                    CoinName      = $MiningPoolHub_Coin
                     Price         = $Stat.Live
                     StablePrice   = $Stat.Week
                     MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/MiningPoolHubCoins.ps1
+++ b/Pools/MiningPoolHubCoins.ps1
@@ -48,7 +48,7 @@ $MiningPoolHubCoins_Request.return | Where-Object {$_.pool_hash -gt 0} | ForEach
         if ($User) {
             [PSCustomObject]@{
                 Algorithm     = $MiningPoolHubCoins_Algorithm_Norm
-                Info          = $MiningPoolHubCoins_Coin
+                CoinName      = $MiningPoolHubCoins_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation
@@ -65,7 +65,7 @@ $MiningPoolHubCoins_Request.return | Where-Object {$_.pool_hash -gt 0} | ForEach
             if ($MiningPoolHubCoins_Algorithm_Norm -eq "Ethash" -and $MiningPoolHubCoins_Coin -NotLike "*ethereum*") {
                 [PSCustomObject]@{
                     Algorithm     = "$($MiningPoolHubCoins_Algorithm_Norm)2gb"
-                    Info          = $MiningPoolHubCoins_Coin
+                    CoinName      = $MiningPoolHubCoins_Coin
                     Price         = $Stat.Live
                     StablePrice   = $Stat.Week
                     MarginOfError = $Stat.Week_Fluctuation
@@ -83,7 +83,7 @@ $MiningPoolHubCoins_Request.return | Where-Object {$_.pool_hash -gt 0} | ForEach
             if ($MiningPoolHubCoins_Algorithm_Norm -eq "CryptonightV7" -or $MiningPoolHubCoins_Algorithm_Norm -eq "Equihash") {
                 [PSCustomObject]@{
                     Algorithm     = $MiningPoolHubCoins_Algorithm_Norm
-                    Info          = $MiningPoolHubCoins_Coin
+                    CoinName      = $MiningPoolHubCoins_Coin
                     Price         = $Stat.Live
                     StablePrice   = $Stat.Week
                     MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/NiceHash.ps1
+++ b/Pools/NiceHash.ps1
@@ -48,7 +48,7 @@ $NiceHash_Request.result.simplemultialgo | Where-Object {$_.paying -gt 0} <# alg
         if ($BTC) {
             [PSCustomObject]@{
                 Algorithm     = $NiceHash_Algorithm_Norm
-                Info          = $NiceHash_Coin
+                CoinName      = $NiceHash_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation
@@ -65,7 +65,7 @@ $NiceHash_Request.result.simplemultialgo | Where-Object {$_.paying -gt 0} <# alg
             if ($NiceHash_Algorithm_Norm -eq "CryptonightV7" -or $NiceHash_Algorithm_Norm -eq "Equihash") {
                 [PSCustomObject]@{
                     Algorithm     = $NiceHash_Algorithm_Norm
-                    Info          = $NiceHash_Coin
+                    CoinName      = $NiceHash_Coin
                     Price         = $Stat.Live
                     StablePrice   = $Stat.Week
                     MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/YiiMP.ps1
+++ b/Pools/YiiMP.ps1
@@ -45,7 +45,7 @@ $YiiMP_Currencies | Where-Object {$YiiMPCoins_Request.$_.hashrate -gt 0} | ForEa
 
         [PSCustomObject]@{
             Algorithm     = $YiiMP_Algorithm_Norm
-            Info          = $YiiMP_Coin
+            CoinName      = $YiiMP_Coin
             Price         = $Stat.Live
             StablePrice   = $Stat.Week
             MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/ZergPool.ps1
+++ b/Pools/ZergPool.ps1
@@ -50,7 +50,7 @@ $ZergPool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Se
             #Option 1
             [PSCustomObject]@{
                 Algorithm     = $ZergPool_Algorithm_Norm
-                Info          = $ZergPool_Coin
+                CoinName      = $ZergPool_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation
@@ -92,7 +92,7 @@ $ZergPool_MiningCurrencies | Where-Object {$ZergPoolCoins_Request.$_.hashrate -g
                 #Option 2
                 [PSCustomObject]@{
                     Algorithm     = $ZergPool_Algorithm_Norm
-                    Info          = $ZergPool_Coin
+                    CoinName      = $ZergPool_Coin
                     Price         = $Stat.Live
                     StablePrice   = $Stat.Week
                     MarginOfError = $Stat.Week_Fluctuation
@@ -112,7 +112,7 @@ $ZergPool_MiningCurrencies | Where-Object {$ZergPoolCoins_Request.$_.hashrate -g
                 #Option 3
                 [PSCustomObject]@{
                     Algorithm     = $ZergPool_Algorithm_Norm
-                    Info          = $ZergPool_Coin
+                    CoinName      = $ZergPool_Coin
                     Price         = $Stat.Live
                     StablePrice   = $Stat.Week
                     MarginOfError = $Stat.Week_Fluctuation

--- a/Pools/Zpool.ps1
+++ b/Pools/Zpool.ps1
@@ -48,7 +48,7 @@ $Zpool_Request | Get-Member -MemberType NoteProperty -ErrorAction Ignore | Selec
         $Zpool_Currencies | ForEach-Object {
             [PSCustomObject]@{
                 Algorithm     = $Zpool_Algorithm_Norm
-                Info          = $Zpool_Coin
+                CoinName      = $Zpool_Coin
                 Price         = $Stat.Live
                 StablePrice   = $Stat.Week
                 MarginOfError = $Stat.Week_Fluctuation

--- a/web/allpools.html
+++ b/web/allpools.html
@@ -22,7 +22,7 @@
     <tr>
       <th data-field="Name" data-sortable="true" data-filter-control="select">Pool</th>
       <th data-field="Algorithm" data-sortable="true" data-filter-control="select">Algorithm</th>
-      <th data-field="Info" data-sortable="true" data-filter-control="select">Info</th>
+      <th data-field="Coin" data-sortable="true" data-filter-control="select">CoinName</th>
       <th data-field="Price" data-align="right" data-sortable="true" data-formatter="formatPrices">BTC/GH/Day</th>
       <th data-field="Host" data-sortable="true" data-filter-control="select">Host</th>
       <th data-field="Updated" data-sortable="true" data-formatter="formatDate">Last Updated</th>

--- a/web/bestpools.html
+++ b/web/bestpools.html
@@ -23,7 +23,7 @@
     <tr>
       <th data-field="Algorithm" data-sortable="true" data-filter-control="select">Algorithm</th>
       <th data-field="Name" data-sortable="true" data-filter-control="select">Name</th>
-      <th data-field="Info" data-sortable="true" data-filter-control="select">Info</th>
+      <th data-field="Coin" data-sortable="true" data-filter-control="select">CoinName</th>
       <th data-field="Price" data-align="right" data-sortable="true" data-formatter="formatPrices">BTC/GH/Day</th>
       <th data-field="Host" data-sortable="true" data-filter-control="select">Host</th>
       <th data-field="Updated" data-sortable="true" data-formatter="formatDate">Last Updated</th>


### PR DESCRIPTION
All we store in this attribute is the coin name so we should name it so.

Why?

Some miners, e.g.Cryptonight, require knowledge of the coin to mined, so we'll use that pool info. By naming it properly we make it more clear what data we are accessing.