### PR TITLE
Still report every minute, even during extended interval

### DIFF
--- a/MultiPoolMiner.ps1
+++ b/MultiPoolMiner.ps1
@@ -93,6 +93,7 @@ $Region = $Region | ForEach-Object {Get-Region $_}
 $Currency = $Currency | ForEach-Object {$_.ToUpper()}
 
 $Timer = (Get-Date).ToUniversalTime()
+$LastReport = $Timer
 $StatEnd = $Timer
 $DecayStart = $Timer
 $DecayPeriod = 60 #seconds
@@ -608,8 +609,6 @@ while ($true) {
         }
     }
 
-    if ($Config.MinerStatusURL -and $Config.MinerStatusKey) {& .\ReportStatus.ps1 -Key $Config.MinerStatusKey -WorkerName $WorkerName -ActiveMiners $ActiveMiners -MinerStatusURL $Config.MinerStatusURL}
-
     Clear-Host
     #Get miners needing benchmarking
     $MinersNeedingBenchmark = @($Miners | Where-Object {$_.HashRates.PSObject.Properties.Value -contains $null})
@@ -716,6 +715,14 @@ while ($true) {
     for ($i = $Strikes; $i -gt 0 -or $Timer -lt $StatEnd; $i--) {
         if ($Downloader) {$Downloader | Receive-Job}
         if ($API.Stop) {Exit}
+
+        if ($Config.MinerStatusURL -and $Config.MinerStatusKey) {
+            if ($Timer -gt $LastReport.AddSeconds($Config.Interval)) {
+                & .\ReportStatus.ps1 -Key $Config.MinerStatusKey -WorkerName $WorkerName -ActiveMiners $ActiveMiners -MinerStatusURL $Config.MinerStatusURL
+                $LastReport = $Timer
+            }
+        }
+
         Start-Sleep 10
         $ActiveMiners | ForEach-Object {
             $Miner = $_


### PR DESCRIPTION
Moves the reporting inside the delay loop, so it can still be done every
$Interval seconds, even when benchmarking miners using extended
intervals.

This ensures the system doesn't appear to be offline during those
periods.