### PR TITLE
Update FireIceAmd.ps1 to 2.4.7

### DIFF
--- a/MinersLegacy/FireiceAmd.ps1
+++ b/MinersLegacy/FireiceAmd.ps1
@@ -9,7 +9,7 @@ $Port = 3336
 
 $Commands = [PSCustomObject]@{
     # "cryptonight"              = "" # CryptoNight is ASIC territory
-	"cryptonight_bittube2"       = "" # CryptoNightHeavyTube
+    "cryptonight_bittube2"       = "" # CryptoNightHeavyTube
     "cryptonight_haven"          = "" # CryptoNightHaven
     "cryptonight_heavy"          = "" # CryptoNightHeavy
     "cryptonight_lite"           = "" # CryptoNightLite

--- a/MinersLegacy/FireiceAmd.ps1
+++ b/MinersLegacy/FireiceAmd.ps1
@@ -1,22 +1,23 @@
 ﻿using module ..\Include.psm1
 
 $Path = ".\Bin\CryptoNight-FireIce\xmr-stak.exe"
-$HashSHA256 = "1BFEAA00CCE185C889F82A2C87DCACABF2EE966B379384470E778E1DA72FB7E1"
-$Uri = "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.5/xmr-stak-win64.zip"
+$HashSHA256 = "2B864D4ED3D3D2678E829E7E270B1BF41898ADCFA1010DDEECE6F863DA27222F"
+$Uri = "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.7/xmr-stak-win64.zip"
 
 $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
 $Port = 3336
 
 $Commands = [PSCustomObject]@{
-    # "cryptonight"           = "" # CryptoNight is ASIC territory
-    "cryptonight_haven"       = "" # CryptoNightHaven
-    "cryptonight_heavy"       = "" # CryptoNightHeavy
-    "cryptonight_lite"        = "" # CryptoNightLite
-    "cryptonight_lite_v7"     = "" # CryptoNightLiteV7
-    "cryptonight_lite_v7_xor" = "" # CryptoNightLiteV7Xor
-    "cryptonight_masari"      = "" # CryptoNightMasari
-    "cryptonight_v7_stellite" = "" # CryptoNightV7Stellite
-    "cryptonight_v7"          = "" # CryptoNightV7
+    # "cryptonight"              = "" # CryptoNight is ASIC territory
+	"cryptonight_bittube2"       = "" # CryptoNightHeavyTube
+    "cryptonight_haven"          = "" # CryptoNightHaven
+    "cryptonight_heavy"          = "" # CryptoNightHeavy
+    "cryptonight_lite"           = "" # CryptoNightLite
+    "cryptonight_lite_v7"        = "" # CryptoNightLiteV7
+    "cryptonight_lite_v7_xor"    = "" # CryptoNightLiteV7Xor
+    "cryptonight_masari"         = "" # CryptoNightMasari
+    "cryptonight_v7_stellite"    = "" # CryptoNightV7Stellite
+    "cryptonight_v7"             = "" # CryptoNightV7
 }
 
 $Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | Where-Object {$Pools.$(Get-Algorithm $_)} | ForEach-Object {

--- a/MinersLegacy/FireiceAmd.ps1
+++ b/MinersLegacy/FireiceAmd.ps1
@@ -10,13 +10,13 @@ $Port = 3336
 $Commands = [PSCustomObject]@{
     # "cryptonight"              = "" # CryptoNight is ASIC territory
     "cryptonight_bittube2"       = "" # CryptoNightHeavyTube
-    "cryptonight_haven"          = "" # CryptoNightHaven
+    "cryptonight_haven"          = "" # CryptoNightHeavyHaven
     "cryptonight_heavy"          = "" # CryptoNightHeavy
     "cryptonight_lite"           = "" # CryptoNightLite
     "cryptonight_lite_v7"        = "" # CryptoNightLiteV7
-    "cryptonight_lite_v7_xor"    = "" # CryptoNightLiteV7Xor
-    "cryptonight_masari"         = "" # CryptoNightMasari
-    "cryptonight_v7_stellite"    = "" # CryptoNightV7Stellite
+    "cryptonight_lite_v7_xor"    = "" # CryptoNightLiteIpbc
+    "cryptonight_masari"         = "" # CryptoNightMsr
+    "cryptonight_v7_stellite"    = "" # CryptoNightXtl
     "cryptonight_v7"             = "" # CryptoNightV7
 }
 


### PR DESCRIPTION
This release adds the new POW function cryptonight_bittube2 and the crypto currency RYO (that we happen to develop!). Support for cryptonight-original coins has been removed, they are mined by ASICs now, but we left in the manual algo setting if you want to test something.

Config files from 2.4.3+ are compatible to this release.

Changelog:
Buffer output in each line # 1672
optimize cn-heavy AMD # 1702
new currencies
ryo # 1703
bittube # 1717
add algorithm cryptonight_bittube2 # 1717
fix spelling # 1660
remove cryptonight coins (algorithm cryptonight is still available) # 1704
Necessary prerequisites
If the application does not start properly, please make sure that Visual Studio libraries are installed.
You can download them from https://go.microsoft.com/fwlink/?LinkId=746572