### PR TITLE
Delete corrupt stat files in Get-Stat

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -247,7 +247,7 @@ function Get-Stat {
             $BaseName = $_.BaseName
             $FullName = $_.FullName
             try {
-                $_ | Get-Content | ConvertFrom-Json -ErrorAction SilentlyContinue | ForEach-Object {
+                $_ | Get-Content -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop | ForEach-Object {
                     $Stats | Add-Member $BaseName $_
                 }
             }

--- a/Include.psm1
+++ b/Include.psm1
@@ -245,8 +245,16 @@ function Get-Stat {
         $Stats = [PSCustomObject]@{}
         Get-ChildItem "Stats" | ForEach-Object {
             $BaseName = $_.BaseName
-            $_ | Get-Content | ConvertFrom-Json -ErrorAction SilentlyContinue | ForEach-Object {
-                $Stats | Add-Member $BaseName $_
+            $FullName = $_.FullName
+            try {
+                $_ | Get-Content | ConvertFrom-Json -ErrorAction SilentlyContinue | ForEach-Object {
+                    $Stats | Add-Member $BaseName $_
+                }
+            }
+            catch {
+                #Remove broken stat file
+                Write-Log -Level Warn "Stat file ($BaseName) is corrupt and will be removed. "
+                Remove-Item -Path  $FullName -Force -Confirm:$false
             }
         }
         Return $Stats

--- a/Include.psm1
+++ b/Include.psm1
@@ -243,7 +243,7 @@ function Get-Stat {
     else {
         # Return all stats
         $Stats = [PSCustomObject]@{}
-        Get-ChildItem "Stats" | ForEach-Object {
+        Get-ChildItem "Stats" -File | ForEach-Object {
             $BaseName = $_.BaseName
             $FullName = $_.FullName
             try {
@@ -253,7 +253,7 @@ function Get-Stat {
             }
             catch {
                 #Remove broken stat file
-                Write-Log -Level Warn "Stat file ($BaseName) is corrupt and will be removed. "
+                Write-Log -Level Warn "Stat file ($BaseName) is corrupt and will be reset. "
                 Remove-Item -Path  $FullName -Force -Confirm:$false
             }
         }


### PR DESCRIPTION
Stale stat files happen if either
- The pool no longer supplies data for an algorithm or coin
- A miner no longer supports an algorithm
- The miner file no longer exists / has been renamed

For 'live' stat files the function 'Set-Stat' automatically repairs/resets broken stats if corruption occurs during runs.
For 'stale' stat files this will not happen and red error messages will re-occur on each loop.

Instead of 'resetting' the stat file in Set-Stat the broken stat files are getting removed in Get-Stat (which reads ALL stat file regardless of state 'live/stale). A simple solution to this problem is implemented in this PR.

Question: Under these circumstances does it still make sense to keep the 'reset stat' code in Set-Stat? Technically it is no longer needed because all broken stats will be gone already.