### PR TITLE
Set-Stat: Do not write errors to transcript on missing stat file

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -119,7 +119,7 @@ function Set-Stat {
     $Stat = Get-Content $Path -ErrorAction SilentlyContinue
     
     try {
-        $Stat | ConvertFrom-Json -ErrorAction Stop
+        $Stat = $Stat | ConvertFrom-Json -ErrorAction Stop
         $Stat = [PSCustomObject]@{
             Live = [Double]$Stat.Live
             Minute = [Double]$Stat.Minute

--- a/Include.psm1
+++ b/Include.psm1
@@ -116,9 +116,10 @@ function Set-Stat {
     $Path = "Stats\$Name.txt"
     $SmallestValue = 1E-20
 
+    $Stat = Get-Content $Path -ErrorAction SilentlyContinue
+    
     try {
-        $Stat = Get-Content $Path -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
-
+        $Stat = $Stat | ConvertFrom-Json -ErrorAction Stop
         $Stat = [PSCustomObject]@{
             Live = [Double]$Stat.Live
             Minute = [Double]$Stat.Minute

--- a/Include.psm1
+++ b/Include.psm1
@@ -119,7 +119,7 @@ function Set-Stat {
     $Stat = Get-Content $Path -ErrorAction SilentlyContinue
     
     try {
-        $Stat = $Stat | ConvertFrom-Json -ErrorAction Stop
+        $Stat | ConvertFrom-Json -ErrorAction Stop
         $Stat = [PSCustomObject]@{
             Live = [Double]$Stat.Live
             Minute = [Double]$Stat.Minute


### PR DESCRIPTION
to transcript if stat file does not exist.

This avoids confusion due to 'expected' and OK error messages in the transcript log.