### PR TITLE
Bminer: Update to version v9.1.0 (Nvidia only)

### DIFF
--- a/MinersLegacy/BMiner.txt
+++ b/MinersLegacy/BMiner.txt
@@ -1,12 +1,12 @@
-﻿{
+{
     "Type":  "NVIDIA",
     "Path":  ".\\Bin\\NVIDIA-BMiner\\BMiner.exe",
-    "HashSHA256": "94F40A763FC4182663A5F3E1885EE4E3EDF1E1DBB69F8CFC170109DB7320081B",
+    "HashSHA256": "779786725E2007368F6F5137DF6F66F8E945F88C62C86FAF71B6E505BFC0A5BC",
     "Arguments":  "\"-api 127.0.0.1:1880 -uri $(if ($Pools.Equihash.SSL) {'stratum+ssl'}else {'stratum'})://$([System.Web.HttpUtility]::UrlEncode($Pools.Equihash.User)):$([System.Web.HttpUtility]::UrlEncode($Pools.Equihash.Pass))@$($Pools.Equihash.Host):$($Pools.Equihash.Port) -nofee -watchdog=false\"",
     "HashRates":  {
                       "Equihash":  "\"$($Stats.Bminer_Equihash_HashRate.Week)\""
                   },
     "API":  "Bminer",
     "Port":  "1880",
-    "URI":  "https://www.bminercontent.com/releases/bminer-lite-v9.0.0-199ca8c-amd64.zip"
+    "URI":  "https://www.bminercontent.com/releases/bminer-lite-v9.1.0-9f41d5c-amd64.zip"
 }


### PR DESCRIPTION
### 9.1.0 (Current)
Substantially increase BTM mining speed (up to 30%).
Fix editing problems of .bat files on windows.
Add scheme suggestions in scripts for ETH mining.

[https://bitcointalk.org/index.php?topic=2519271.0](url)