### PR TITLE
Fix downloader behavior on PowerShell 6.1.0

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -468,7 +468,7 @@ function Expand-WebRequest {
             Rename-Item $Path_Old (Split-Path $Path -Leaf)
         }
         else {
-            Get-ChildItem $Path_Old | Where-Object PSIsContainer -EQ $true | ForEach-Object {Move-Item (Join-Path $Path_Old $_) $Path_New}
+            Get-ChildItem $Path_Old | Where-Object PSIsContainer -EQ $true | ForEach-Object {Move-Item $_.FullName $Path_New}
             Remove-Item $Path_Old
         }
     }


### PR DESCRIPTION
This fixes download errors with zips which have a single directory on the root (such as CcminerNanashi) when running MPM under PowerShell 6.1.0 final.

It appears that `$_` on the affected snippet now expands to the full path when cast to a string, resulting in `Move-Item` being called on a double absolute path, which obviously failed to move the zip's directory to the desired location. My fix is backwards compatible with 6.0.2.

![Behavior of ChildItem-string casting on PowerShell 6.0.2 and 6.1.0](https://i.imgur.com/CgkfNFs.png)