### PR TITLE
Update Include.psm1, Added Background start script

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -50,7 +50,7 @@ function Get-Balance {
     $Config.Currency | ForEach-Object {
         $Currency = $_.ToUpper()
         #Get number of digits from $NewRates
-        if ($NewRates.$Currency -ne $null) {$Digits = ($($NewRates.$Currency).ToString().Split(".")[1]).length}else {$Digits = 8}
+        if ($NewRates.$Currency -ne $null) {$Digits = ($NewRates.$Currency).length - ([Int]($NewRates.$Currency)).length - 1} else {$Digits = 8}
         $Balances | Foreach-Object {
             $_ | Add-Member "Total1 in $Currency" $(if ($Rates.$($_.Currency).$Currency) {$_.Total * [Float]$Rates.$($_.Currency).$Currency}) -Force  
             $_ | Add-Member "Value in $Currency" $(if ($Rates.$($_.Currency).$Currency) {("{0:N$($Digits)}" -f ([Float]$_.Total * [Float]$Rates.$($_.Currency).$Currency))}else {"unknown"}) -Force

--- a/Include.psm1
+++ b/Include.psm1
@@ -37,7 +37,7 @@ function Get-Balance {
     $Rates.PSObject.Properties.Name | ForEach-Object {
         $Currency = $_.ToUpper()
         $Balances | Foreach-Object {
-            if ($NewRates.$Currency -ne $null) {$Digits = ($($NewRates.$Currency).ToString().Split(".")[1]).length}else {$Digits = 8}
+            if ($NewRates.$Currency -ne $null) {$Digits = ($NewRates.$Currency).length - ([Int]($NewRates.$Currency)).length - 1} else {$Digits = 8}
            # $_.Total = ("{0:N$($Digits)}" -f ([Float]$($_.Total)))
             if ($Currency -eq $_.Currency) {
                 $_ | Add-Member "Balance ($Currency)" ("{0:N$($Digits)}" -f ([Float]$($_.Total)))

--- a/Include.psm1
+++ b/Include.psm1
@@ -38,12 +38,12 @@ function Get-Balance {
         $Currency = $_.ToUpper()
         $Balances | Foreach-Object {
             if ($NewRates.$Currency -ne $null) {$Digits = ($($NewRates.$Currency).ToString().Split(".")[1]).length}else {$Digits = 8}
-            $_.Total = ("{0:N$($Digits)}" -f ([Float]$($_.Total)))
+           # $_.Total = ("{0:N$($Digits)}" -f ([Float]$($_.Total)))
             if ($Currency -eq $_.Currency) {
-                $_ | Add-Member "Balance ($Currency)" $_.Total
+                $_ | Add-Member "Balance ($Currency)" ("{0:N$($Digits)}" -f ([Float]$($_.Total)))
             }
         }
-        if (($Balances."Balance ($Currency)" | Measure-Object -Sum).sum) {$Totals | Add-Member "Balance ($Currency)" ("{0:N$($Digits)}" -f ([Float]$($Balances."Balance ($Currency)" | Measure-Object -Sum).sum))}
+        if (($Balances.Total | Measure-Object -Sum).sum) {$Totals | Add-Member "Balance ($Currency)" ("{0:N$($Digits)}" -f ([Float]$($Balances.Total | Measure-Object -Sum).sum))}
     }
 
     #Add converted values
@@ -52,9 +52,10 @@ function Get-Balance {
         #Get number of digits from $NewRates
         if ($NewRates.$Currency -ne $null) {$Digits = ($($NewRates.$Currency).ToString().Split(".")[1]).length}else {$Digits = 8}
         $Balances | Foreach-Object {
+            $_ | Add-Member "Total1 in $Currency" $(if ($Rates.$($_.Currency).$Currency) {$_.Total * [Float]$Rates.$($_.Currency).$Currency}) -Force  
             $_ | Add-Member "Value in $Currency" $(if ($Rates.$($_.Currency).$Currency) {("{0:N$($Digits)}" -f ([Float]$_.Total * [Float]$Rates.$($_.Currency).$Currency))}else {"unknown"}) -Force
         }
-        if (($Balances."Value in $Currency" | Measure-Object -Sum -ErrorAction Ignore).sum) {$Totals | Add-Member "Value in $Currency" ("{0:N$($Digits)}" -f ([Float]$($Balances."Value in $Currency" | Measure-Object -Sum -ErrorAction Ignore).sum)) -Force}
+        if (($Balances."Total1 in $Currency" | Measure-Object -Sum -ErrorAction Ignore).sum)  {$Totals | Add-Member "Value in $Currency" ("{0:N$($Digits)}" -f ([Float]$($Balances."Total1 in $Currency" | Measure-Object -Sum -ErrorAction Ignore).sum)) -Force}
     }
     $Balances += $Totals
 

--- a/Start_background.bat
+++ b/Start_background.bat
@@ -1,0 +1,18 @@
+﻿@cd /d %~dp0
+
+@if not "%GPU_FORCE_64BIT_PTR%"=="1" (setx GPU_FORCE_64BIT_PTR 1) > nul
+@if not "%GPU_MAX_HEAP_SIZE%"=="100" (setx GPU_MAX_HEAP_SIZE 100) > nul
+@if not "%GPU_USE_SYNC_OBJECTS%"=="1" (setx GPU_USE_SYNC_OBJECTS 1) > nul
+@if not "%GPU_MAX_ALLOC_PERCENT%"=="100" (setx GPU_MAX_ALLOC_PERCENT 100) > nul
+@if not "%GPU_SINGLE_ALLOC_PERCENT%"=="100" (setx GPU_SINGLE_ALLOC_PERCENT 100) > nul
+@if not "%CUDA_DEVICE_ORDER%"=="PCI_BUS_ID" (setx CUDA_DEVICE_ORDER PCI_BUS_ID) > nul
+
+@set "command=& .\multipoolminer.ps1 -Wallet 1Q24z7gHPDbedkaWDTFqhMF8g7iHMehsCb -UserName aaronsace -WorkerName multipoolminer -Region europe -Currency btc,usd,eur -DeviceName amd,nvidia,cpu -PoolName miningpoolhubcoins,zpool,nicehash -Algorithm blake2s,cryptonightV7,cryptonightheavy,decrednicehash,ethash,ethash2gb,ethash3gb,equihash,keccak,lbry,lyra2re2,lyra2z,m7m,neoscrypt,pascal,sib,skein,skunk,x16r -Donate 24 -Watchdog -MinerStatusURL https://multipoolminer.io/monitor/miner.php -SwitchingPrevention 2"
+
+powershell -executionpolicy bypass .\Wrapper.ps1
+
+pwsh -noexit -executionpolicy bypass  -command "%command%"  > .\Logs\MainWindow.txt
+powershell -version 5.0 -noexit -executionpolicy bypass  -command "%command%" > .\Logs\MainWindow.txt
+pwsh -noexit -executionpolicy bypass  -command "%command%" >.\Logs\MainWindow.txt
+
+pause

--- a/Start_log.bat
+++ b/Start_log.bat
@@ -1,0 +1,18 @@
+﻿@cd /d %~dp0
+
+@if not "%GPU_FORCE_64BIT_PTR%"=="1" (setx GPU_FORCE_64BIT_PTR 1) > nul
+@if not "%GPU_MAX_HEAP_SIZE%"=="100" (setx GPU_MAX_HEAP_SIZE 100) > nul
+@if not "%GPU_USE_SYNC_OBJECTS%"=="1" (setx GPU_USE_SYNC_OBJECTS 1) > nul
+@if not "%GPU_MAX_ALLOC_PERCENT%"=="100" (setx GPU_MAX_ALLOC_PERCENT 100) > nul
+@if not "%GPU_SINGLE_ALLOC_PERCENT%"=="100" (setx GPU_SINGLE_ALLOC_PERCENT 100) > nul
+@if not "%CUDA_DEVICE_ORDER%"=="PCI_BUS_ID" (setx CUDA_DEVICE_ORDER PCI_BUS_ID) > nul
+
+
+
+powershell -executionpolicy bypass .\Wrapper.ps1
+start pwsh -noexit -executionpolicy bypass -command "& .\reader.ps1 -log 'MultiPoolMiner_\d\d\d\d-\d\d-\d\d\.txt' -sort '^[^_]*_' -quickstart"
+start pwsh -noexit -executionpolicy bypass -command "& .\reader.ps1 -log '^((?!MultiPoolMiner_.+\.txt).)*$' -sort '^[^_]*_' -quickstart"
+start pwsh -noexit -executionpolicy bypass -command "& .\reader.ps1 -log 'MainWindow.txt'  -quickstart"
+
+
+pause


### PR DESCRIPTION
fix Get-Balance , it shows  values not correctly  when -ShowPoolBalances and -ShowPoolBalancesDetails options are enabled.


Split start.bat in two scripts, for run multipoolminer automatically at startup without to  have to login or autologin.  
To run multipoolminer at Windows startup also with user with password:
-Add Start_background.bat to task scheduler in order to automatically run multipoolminer at windows startup.
-Add Start_log.bat in shell:startup to see logs when log in the user account.