### PR TITLE
 ccminerbmw512 x86 version 

### DIFF
--- a/MinersLegacy/CcminerBMW512-v2.2.5.ps1
+++ b/MinersLegacy/CcminerBMW512-v2.2.5.ps1
@@ -20,14 +20,6 @@ if (-not $Miner_Config) {$Miner_Config = $Config.MinersLegacy.$Miner_BaseName."*
 
 $Devices = @($Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "NVIDIA Corporation")
 
-# Miner requires CUDA 9.1 or higher
-$CUDAVersion = ($Devices.OpenCL.Platform.Version | Select-Object -Unique) -replace ".*CUDA ",""
-$RequiredCUDAVersion = "9.1.00"
-if ($CUDAVersion -and [System.Version]$CUDAVersion -lt [System.Version]$RequiredCUDAVersion) {
-    Write-Log -Level Warn "Miner ($($Name)) requires CUDA version $($RequiredCUDAVersion) or above (installed version is $($CUDAVersion)). Please update your Nvidia drivers. "
-    return
-}
-
 $Commands = [PSCustomObject]@{
     "Bmw512" = " -a bmw" #Bmw512
 }

--- a/MinersLegacy/CcminerBMW512.ps1
+++ b/MinersLegacy/CcminerBMW512.ps1
@@ -22,7 +22,7 @@ $Devices = @($Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "N
 
 # Miner requires CUDA 9.1 or higher
 $CUDAVersion = ($Devices.OpenCL.Platform.Version | Select-Object -Unique) -replace ".*CUDA ",""
-$RequiredCUDAVersion = "9.2.00"
+$RequiredCUDAVersion = "9.1.00"
 if ($CUDAVersion -and [System.Version]$CUDAVersion -lt [System.Version]$RequiredCUDAVersion) {
     Write-Log -Level Warn "Miner ($($Name)) requires CUDA version $($RequiredCUDAVersion) or above (installed version is $($CUDAVersion)). Please update your Nvidia drivers. "
     return

--- a/MinersLegacy/CcminerBMW512.ps1
+++ b/MinersLegacy/CcminerBMW512.ps1
@@ -35,7 +35,7 @@ $Commands = [PSCustomObject]@{
 if ($Miner_Config.Commands) {$Miner_Config.Commands | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | ForEach-Object {$Commands | Add-Member $_ $($Miner_Config.Commands.$_) -Force}}
 
 #CommonCommands from config file take precedence
-if ($Miner_Config.CommonCommands) {$CommonCommands = $Miner_Config.CommonCommands = $Miner_Config.CommonCommands}
+if ($Miner_Config.CommonCommands) {$CommonCommands = $Miner_Config.CommonCommands}
 else {$CommonCommands = ""}
 
 $Devices | Select-Object Model -Unique | ForEach-Object {

--- a/MinersLegacy/CcminerBMW512.ps1
+++ b/MinersLegacy/CcminerBMW512.ps1
@@ -9,8 +9,8 @@ param(
 
 $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName)"
 $Path = ".\Bin\$($Name)\ccminer.exe"
-$HashSHA256 = "7962745B0E110F16CD0DE2527143E4E7A6F37860BDE3910431CC850E079F2268"
-$Uri = "https://github.com/Minerx117/ccminer-bmw512/releases/download/v2.2.5/ccminerbmw.7z"
+$HashSHA256 = "6E9B037C01A1B09DA010FFFFF14779DA31E3EB73379763C60ECC0B337895D23A"
+$Uri = "https://github.com/Minerx117/ccminer-bmw512/releases/download/v2.2.5-x86/ccminerbmw512x86.7z"
 $ManualUri = "https://github.com/pallas1/ccminer-bmw512"
 
 $Miner_BaseName = $Name -split '-' | Select-Object -Index 0
@@ -20,9 +20,9 @@ if (-not $Miner_Config) {$Miner_Config = $Config.MinersLegacy.$Miner_BaseName."*
 
 $Devices = @($Devices | Where-Object Type -EQ "GPU" | Where-Object Vendor -EQ "NVIDIA Corporation")
 
-# Miner requires CUDA 10.0.00 or higher
+# Miner requires CUDA 9.1 or higher
 $CUDAVersion = ($Devices.OpenCL.Platform.Version | Select-Object -Unique) -replace ".*CUDA ",""
-$RequiredCUDAVersion = "10.0.00"
+$RequiredCUDAVersion = "9.2.00"
 if ($CUDAVersion -and [System.Version]$CUDAVersion -lt [System.Version]$RequiredCUDAVersion) {
     Write-Log -Level Warn "Miner ($($Name)) requires CUDA version $($RequiredCUDAVersion) or above (installed version is $($CUDAVersion)). Please update your Nvidia drivers. "
     return


### PR DESCRIPTION
improve compatibility (cuda 9.1) same speed or faster than previous compile works with RTX and Turing GPU's

VC++2013 cuda 9.1 x86

note: not sure if you still need # Miner requires CUDA 9.1 or higher warning as cuda 9.1 is compatible with almost all drivers