### PR TITLE
Fixes and miner updates

### DIFF
--- a/Include.psm1
+++ b/Include.psm1
@@ -1038,7 +1038,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = (($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1093,7 +1093,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1154,7 +1154,7 @@ function Get-Device {
                     }
 
                     $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                     if ($Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus) { 
                         $Device = $Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus

--- a/Include.psm1
+++ b/Include.psm1
@@ -88,7 +88,6 @@ function Get-PrePostCommand {
 
     #Get Pre / Post miner exec commands
 
-
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -1073,7 +1072,7 @@ function Get-Device {
                     Name   = $null
                     Model  = $Device_CIM.Name
                     Type   = "GPU"
-                    Bus    = if ($Device_PNP.DEVPKEY_Device_BusNumber -is [Int64]) { $Device_PNP.DEVPKEY_Device_BusNumber }
+                    Bus    = $(if ($Device_PNP.DEVPKEY_Device_BusNumber -is [Int32] -or $Device_PNP.DEVPKEY_Device_BusNumber -is [Int64]) { $Device_PNP.DEVPKEY_Device_BusNumber })
                     Vendor = $(
                         switch -Regex ([String]$Device_CIM.AdapterCompatibility) { 
                             "Advanced Micro Devices" { "AMD" }
@@ -1094,7 +1093,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
+                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1134,7 +1133,7 @@ function Get-Device {
                                 default { [String]$Device_OpenCL.Type -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]' }
                             }
                         )
-                        Bus    = if ($Device_OpenCL.PCIBus -is [Int64]) { $Device_OpenCL.PCIBus }
+                        Bus    = $(if ($Device_OpenCL.PCIBus -is [Int32] -or $Device_OpenCL.PCIBus -is [Int64]) { $Device_OpenCL.PCIBus })
                         Vendor = $(
                             switch -Regex ([String]$Device_OpenCL.Vendor) { 
                                 "Advanced Micro Devices" { "AMD" }
@@ -1207,7 +1206,7 @@ function Get-Device {
                 $PlatformId++
             }
 
-            $Global:Devices | Sort-Object Bus | ForEach-Object { 
+            $Global:Devices | Where-Object Bus | Sort-Object Bus | ForEach-Object { 
                 $_ | Add-Member @{ 
                     Slot             = [Int]$Slot
                     Type_Slot        = [Int]$Type_Slot.($_.Type)

--- a/Include.psm1
+++ b/Include.psm1
@@ -88,7 +88,6 @@ function Get-PrePostCommand {
 
     #Get Pre / Post miner exec commands
 
-
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Include.psm1
+++ b/Include.psm1
@@ -1038,7 +1038,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                $Device.Model = (($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1093,7 +1093,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1154,7 +1154,7 @@ function Get-Device {
                     }
 
                     $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                     if ($Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus) { 
                         $Device = $Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus

--- a/Include.psm1
+++ b/Include.psm1
@@ -1039,7 +1039,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
+                $Device.Model = (($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1094,7 +1094,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
+                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1155,7 +1155,7 @@ function Get-Device {
                     }
 
                     $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
+                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor', 'CPU' -replace 'Graphics', 'GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
 
                     if ($Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus) { 
                         $Device = $Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus

--- a/Include.psm1
+++ b/Include.psm1
@@ -1038,7 +1038,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1154,7 +1154,7 @@ function Get-Device {
                     }
 
                     $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
 
                     if ($Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus) { 
                         $Device = $Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus

--- a/Include.psm1
+++ b/Include.psm1
@@ -1206,7 +1206,7 @@ function Get-Device {
                 $PlatformId++
             }
 
-            $Global:Devices | Where-Object { $_.Bus -is [Int64] -or $_.Bus -is [Int32] } | Sort-Object Bus | ForEach-Object { 
+            $Global:Devices | Where-Object Bus | Sort-Object Bus | ForEach-Object { 
                 $_ | Add-Member @{ 
                     Slot             = [Int]$Slot
                     Type_Slot        = [Int]$Type_Slot.($_.Type)

--- a/Include.psm1
+++ b/Include.psm1
@@ -1072,7 +1072,11 @@ function Get-Device {
                     Name   = $null
                     Model  = $Device_CIM.Name
                     Type   = "GPU"
-                    Bus    = if ($Device_PNP.DEVPKEY_Device_BusNumber -is [Int64]) { $Device_PNP.DEVPKEY_Device_BusNumber }
+                    Bus    = $(
+                        if ($Device_PNP.DEVPKEY_Device_BusNumber -is [Int64] -or $Device_PNP.DEVPKEY_Device_BusNumber -is [Int32]) { 
+                            [Int64]$Device_PNP.DEVPKEY_Device_BusNumber
+                        }
+                    )
                     Vendor = $(
                         switch -Regex ([String]$Device_CIM.AdapterCompatibility) { 
                             "Advanced Micro Devices" { "AMD" }
@@ -1133,7 +1137,11 @@ function Get-Device {
                                 default { [String]$Device_OpenCL.Type -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]' }
                             }
                         )
-                        Bus    = if ($Device_OpenCL.PCIBus -is [Int64]) { $Device_OpenCL.PCIBus }
+                        Bus    = $(
+                            if ($Device_OpenCL.PCIBus -is [Int64] -or $Device_OpenCL.PCIBus -is [Int32]) { 
+                                [Int64]$Device_OpenCL.PCIBus
+                            }
+                        )
                         Vendor = $(
                             switch -Regex ([String]$Device_OpenCL.Vendor) { 
                                 "Advanced Micro Devices" { "AMD" }
@@ -1206,7 +1214,7 @@ function Get-Device {
                 $PlatformId++
             }
 
-            $Global:Devices | Sort-Object Bus | ForEach-Object { 
+            $Global:Devices | Where-Object Bus -Is [Int64] | Sort-Object Bus | ForEach-Object { 
                 $_ | Add-Member @{ 
                     Slot             = [Int]$Slot
                     Type_Slot        = [Int]$Type_Slot.($_.Type)

--- a/Include.psm1
+++ b/Include.psm1
@@ -88,6 +88,7 @@ function Get-PrePostCommand {
 
     #Get Pre / Post miner exec commands
 
+
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -1072,7 +1073,7 @@ function Get-Device {
                     Name   = $null
                     Model  = $Device_CIM.Name
                     Type   = "GPU"
-                    Bus    = $(if ($Device_PNP.DEVPKEY_Device_BusNumber -is [Int32] -or $Device_PNP.DEVPKEY_Device_BusNumber -is [Int64]) { $Device_PNP.DEVPKEY_Device_BusNumber })
+                    Bus    = if ($Device_PNP.DEVPKEY_Device_BusNumber -is [Int64]) { $Device_PNP.DEVPKEY_Device_BusNumber }
                     Vendor = $(
                         switch -Regex ([String]$Device_CIM.AdapterCompatibility) { 
                             "Advanced Micro Devices" { "AMD" }
@@ -1093,7 +1094,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
+                $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1133,7 +1134,7 @@ function Get-Device {
                                 default { [String]$Device_OpenCL.Type -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]' }
                             }
                         )
-                        Bus    = $(if ($Device_OpenCL.PCIBus -is [Int32] -or $Device_OpenCL.PCIBus -is [Int64]) { $Device_OpenCL.PCIBus })
+                        Bus    = if ($Device_OpenCL.PCIBus -is [Int64]) { $Device_OpenCL.PCIBus }
                         Vendor = $(
                             switch -Regex ([String]$Device_OpenCL.Vendor) { 
                                 "Advanced Micro Devices" { "AMD" }
@@ -1206,7 +1207,7 @@ function Get-Device {
                 $PlatformId++
             }
 
-            $Global:Devices | Where-Object Bus | Sort-Object Bus | ForEach-Object { 
+            $Global:Devices | Sort-Object Bus | ForEach-Object { 
                 $_ | Add-Member @{ 
                     Slot             = [Int]$Slot
                     Type_Slot        = [Int]$Type_Slot.($_.Type)

--- a/Include.psm1
+++ b/Include.psm1
@@ -1038,7 +1038,7 @@ function Get-Device {
                 }
 
                 $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
+                $Device.Model = (($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor) -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                 if (-not $Type_Vendor_Id.($Device.Type)) { 
                     $Type_Vendor_Id.($Device.Type) = @{ }
@@ -1154,7 +1154,7 @@ function Get-Device {
                     }
 
                     $Device.Name = "$($Device.Type)#$('{0:D2}' -f $Device.Type_Id)"
-                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)' -replace '[^A-Z0-9]'
+                    $Device.Model = ((($Device.Model -split ' ' -replace 'Processor','CPU' -replace 'Graphics','GPU') -notmatch $Device.Type -notmatch $Device.Vendor -notmatch "$([UInt64]($Device.Memory/1GB))GB") + "$([UInt64]($Device.Memory/1GB))GB") -join ' ' -replace '\(R\)|\(TM\)|\(C\)|Series' -replace '[^A-Z0-9]'
 
                     if ($Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus) { 
                         $Device = $Global:Devices | Where-Object Type -EQ $Device.Type | Where-Object Bus -EQ $Device.Bus

--- a/MinersLegacy/Gminer-v1.74.ps1
+++ b/MinersLegacy/Gminer-v1.74.ps1
@@ -9,8 +9,8 @@ param(
 
 $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName)"
 $Path = ".\Bin\$($Name)\miner.exe"
-$HashSHA256 = "5E7949F710F71E8F6C225C38B78C6F3134FE6291B99E71D9B187529408728D21"
-$Uri = "https://github.com/develsoftware/GMinerRelease/releases/download/1.73/gminer_1_73_windows64.zip"
+$HashSHA256 = ""
+$Uri = "https://github.com/develsoftware/GMinerRelease/releases/download/1.74/gminer_1_74_windows64.zip"
 $ManualUri = "https://bitcointalk.org/index.php?topic=5034735.0"
 
 $Miner_Config = Get-MinerConfig -Name $Name -Config $Config

--- a/MinersLegacy/MiniZEquihash-v1.5s.ps1
+++ b/MinersLegacy/MiniZEquihash-v1.5s.ps1
@@ -9,8 +9,8 @@ param(
 
 $Name = "$(Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName)"
 $Path = ".\Bin\$($Name)\MiniZ.exe"
-$HashSHA256 = "F1FEB04097E33DB3A45F3D60EAC386E5EA1212FE1FCC157CA33A59A26EB5B4D5"
-$Uri = "https://github.com/MultiPoolMiner/miner-binaries/releases/download/MiniZ/miniZ_v1.5r_cuda10_win-x64.zip"
+$HashSHA256 = "733963787DD61894DB05297232CB046DB5C3247B601262CD3C26A31DAC25F54A"
+$Uri = "https://github.com/MultiPoolMiner/miner-binaries/releases/download/MiniZ/miniZ_v1.5s_cuda10_win-x64.zip"
 $ManualUri = "https://miniz.ch/download"
 
 $Miner_Config = Get-MinerConfig -Name $Name -Config $Config

--- a/MinersLegacy/PhoenixminerEthash-v4.7c.ps1
+++ b/MinersLegacy/PhoenixminerEthash-v4.7c.ps1
@@ -135,7 +135,7 @@ $Devices | Select-Object Vendor, Model -Unique | ForEach-Object {
                     DeviceName         = $Miner_Device.Name
                     Path               = $Path
                     HashSHA256         = $HashSHA256
-                    Arguments          = ("$Command$CommonCommands$($Coin.ToLower()) -mport -$Miner_Port$(if(($Pools.$Algorithm_Norm.Name -like "NiceHash*" -or $Pools.$Algorithm_Norm.Name -like "MiningPoolHub*") -and $Algorithm_Norm -like "Ethash*") { " -proto 4" }) -pool $(if ($Pools.$Algorithm_Norm.SSL) { "ssl://" })$($Pools.$Algorithm_Norm.Host):$($Pools.$Algorithm_Norm.Port) -wal $($Pools.$Algorithm_Norm.User) -pass $($Pools.$Algorithm_Norm.Pass)$Arguments_Primary$Arguments_Secondary$TurboKernel -gpus $(($Miner_Device | ForEach-Object { '{0:x}' -f ($_.Type_PlatformId_Slot + 1) }) -join ',')" -replace "\s+", " ").trim()
+                    Arguments          = ("$Command$CommonCommands$($Coin.ToLower()) -mport -$Miner_Port$(if(($Pools.$Algorithm_Norm.Name -like "NiceHash*" -or $Pools.$Algorithm_Norm.Name -like "MiningPoolHub*") -and $Algorithm_Norm -like "Ethash*") { " -proto 4" }) -pool $(if ($Pools.$Algorithm_Norm.SSL) { "ssl://" })$($Pools.$Algorithm_Norm.Host):$($Pools.$Algorithm_Norm.Port) -wal $($Pools.$Algorithm_Norm.User) -pass $($Pools.$Algorithm_Norm.Pass)$Arguments_Primary$Arguments_Secondary$TurboKernel -gpus $(($Miner_Device | ForEach-Object { '{0:x}' -f ($_.Type_Vendor_Slot + 1) }) -join ',')" -replace "\s+", " ").trim()
                     HashRates          = $Miner_HashRates
                     API                = "Claymore"
                     Port               = $Miner_Port


### PR DESCRIPTION
Miner updates
- Update SRBMinerMulti-v0.1.6beta
- Update Gminer-v1.74
- Update MiniZEquihash-v1.6s

Fixes
- Fix compatibility with powershell 5.1
- Fix compatibility with 32bit version
- PhoenixminerEthash-v4.7c.ps1: Fix device enumeration (regression from new Get-Device)

Cosmetic changes
- Strip 'Series' from model naming